### PR TITLE
Typo in code snippet

### DIFF
--- a/docs/scos/dev/feature-integration-guides/202009.0/cms-feature-integration.md
+++ b/docs/scos/dev/feature-integration-guides/202009.0/cms-feature-integration.md
@@ -407,13 +407,14 @@ class EventBehaviorDependencyProvider extends SprykerEventBehaviorDependencyProv
     protected function getEventTriggerResourcePlugins()
     {
         return [
-            new CmsPageEventResourceQueryContainerPluginCmsBlockEventResourceQueryContainerPlugin(),
-            new CmsBlockEventResourceQueryContainerPluginCmsEventResourceQueryContainerPlugin(),
-            new CmsEventResourceQueryContainerPluginCmsSlotBlockEventResourceBulkRepositoryPlugin(),
-            new CmsSlotBlockEventResourceBulkRepositoryPluginCmsSlotEventResourceBulkRepositoryPlugin(),
-            			new CmsSlotEventResourceBulkRepositoryPluginContentStorageEventResourceBulkRepositoryPlugin(),
+            new CmsPageEventResourceQueryContainerPlugin(),
+            new CmsBlockEventResourceQueryContainerPlugin(),
+            new CmsEventResourceQueryContainerPlugin(),
+            new CmsSlotBlockEventResourceBulkRepositoryPlugin(),
+            new CmsSlotEventResourceBulkRepositoryPlugin(),
+	    new ContentStorageEventResourceBulkRepositoryPlugin(),
 
-			// Optional subscribers, use only if you need CMS Block relationship with categories or products.
+	    // Optional subscribers, use only if you need CMS Block relationship with categories or products.
             new CmsBlockCategoryEventResourceQueryContainerPlugin(),
             new CmsBlockProductEventResourceQueryContainerPlugin(),
         ];


### PR DESCRIPTION
Typo with functions in src/Pyz/Zed/EventBehavior/EventBehaviorDependencyProvider.php:

new CmsPageEventResourceQueryContainerPluginCmsBlockEventResourceQueryContainerPlugin(),
new CmsBlockEventResourceQueryContainerPluginCmsEventResourceQueryContainerPlugin(),
new CmsEventResourceQueryContainerPluginCmsSlotBlockEventResourceBulkRepositoryPlugin(),
new CmsSlotBlockEventResourceBulkRepositoryPluginCmsSlotEventResourceBulkRepositoryPlugin(),
new CmsSlotEventResourceBulkRepositoryPluginContentStorageEventResourceBulkRepositoryPlugin(),



## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
