### PR TITLE
Typo in code snippet

### DIFF
--- a/docs/scos/dev/feature-integration-guides/202009.0/cms-feature-integration.md
+++ b/docs/scos/dev/feature-integration-guides/202009.0/cms-feature-integration.md
@@ -407,13 +407,14 @@ class EventBehaviorDependencyProvider extends SprykerEventBehaviorDependencyProv
     protected function getEventTriggerResourcePlugins()
     {
         return [
-            new CmsPageEventResourceQueryContainerPluginCmsBlockEventResourceQueryContainerPlugin(),
-            new CmsBlockEventResourceQueryContainerPluginCmsEventResourceQueryContainerPlugin(),
-            new CmsEventResourceQueryContainerPluginCmsSlotBlockEventResourceBulkRepositoryPlugin(),
-            new CmsSlotBlockEventResourceBulkRepositoryPluginCmsSlotEventResourceBulkRepositoryPlugin(),
-            			new CmsSlotEventResourceBulkRepositoryPluginContentStorageEventResourceBulkRepositoryPlugin(),
+            new CmsPageEventResourceQueryContainerPlugin(),
+            new CmsBlockEventResourceQueryContainerPlugin(),
+            new CmsEventResourceQueryContainerPlugin(),
+            new CmsSlotBlockEventResourceBulkRepositoryPlugin(),
+            new CmsSlotEventResourceBulkRepositoryPlugin(),
+	    new ContentStorageEventResourceBulkRepositoryPlugin(),
 
-			// Optional subscribers, use only if you need CMS Block relationship with categories or products.
+	    // Optional subscribers, use only if you need CMS Block relationship with categories or products.
             new CmsBlockCategoryEventResourceQueryContainerPlugin(),
             new CmsBlockProductEventResourceQueryContainerPlugin(),
         ];


### PR DESCRIPTION
src/Pyz/Zed/EventBehavior/EventBehaviorDependencyProvider.php

Typo with functions:
new CmsPageEventResourceQueryContainerPluginCmsBlockEventResourceQueryContainerPlugin(),
            new CmsBlockEventResourceQueryContainerPluginCmsEventResourceQueryContainerPlugin(),
            new CmsEventResourceQueryContainerPluginCmsSlotBlockEventResourceBulkRepositoryPlugin(),
            new CmsSlotBlockEventResourceBulkRepositoryPluginCmsSlotEventResourceBulkRepositoryPlugin(),
           			new CmsSlotEventResourceBulkRepositoryPluginContentStorageEventResourceBulkRepositoryPlugin(),

new CmsPageEventResourceQueryContainerPlugin(),
            new CmsBlockEventResourceQueryContainerPlugin(),
            new CmsEventResourceQueryContainerPlugin(),
            new CmsSlotBlockEventResourceBulkRepositoryPlugin(),
            new CmsSlotEventResourceBulkRepositoryPlugin(),
	    new ContentStorageEventResourceBulkRepositoryPlugin(),

	    // Optional subscribers, use only if you need CMS Block relationship with categories or products.
            new CmsBlockCategoryEventResourceQueryContainerPlugin(),
            new CmsBlockProductEventResourceQueryContainerPlugin(),

## PR Description

TBD

## Checklist
- [ ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
