### PR TITLE
QueueQueue and a method name typoes

### DIFF
--- a/docs/scos/dev/back-end-development/data-manipulation/data-publishing/handling-data-with-publish-and-synchronization.md
+++ b/docs/scos/dev/back-end-development/data-manipulation/data-publishing/handling-data-with-publish-and-synchronization.md
@@ -844,7 +844,7 @@ class RabbitMqConfig extends SprykerRabbitMqConfig
     }
 ```
 
-3. Add `MessageProcessor` for the queue to `\Pyz\Zed\QueueQueueDependencyProvider::getProcessorMessagePlugins()`:
+3. Add `MessageProcessor` for the queue to `\Pyz\Zed\Queue\QueueDependencyProvider::getProcessorMessagePlugins()`:
 
 ```php
 <?php
@@ -858,7 +858,7 @@ class QueueDependencyProvider extends SprykerDependencyProvider
     /**
      * @return array
      */
-    protected function getSynchronizationQueueConfiguration(): array
+    protected function getProcessorMessagePlugins(): array
     {
         return [
             ...


### PR DESCRIPTION
I fixed a name of a method that doesn't belong to QueueDependencyProvider and corrected QueueQueueDependencyProvider to Queue\QueueDependencyProvider.

## PR Description

TBD

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
