### PR TITLE
Update installing-in-demo-mode-on-macos-and-linux.md

### DIFF
--- a/docs/scos/dev/setup/installing-spryker-with-docker/installation-guides/installing-in-demo-mode-on-macos-and-linux.md
+++ b/docs/scos/dev/setup/installing-spryker-with-docker/installation-guides/installing-in-demo-mode-on-macos-and-linux.md
@@ -89,7 +89,7 @@ docker/sdk up
 8. Update the `hosts` file:
 
 ```bash
-echo "127.0.0.1 zed.de.spryker.local yves.de.spryker.local glue.de.spryker.local zed.at.spryker.local yves.at.spryker.local glue.at.spryker.local zed.us.spryker.local yves.us.spryker.local glue.us.spryker.local mail.spryker.local scheduler.spryker.local queue.spryker.local" | sudo tee -a /etc/hosts
+echo "127.0.0.1 zed.de.spryker.local yves.de.spryker.local glue.de.spryker.local zed.at.spryker.local yves.at.spryker.local glue.at.spryker.local zed.us.spryker.local yves.us.spryker.local glue.us.spryker.local mail.spryker.local scheduler.spryker.local queue.spryker.local backoffice.de.spryker.local" | sudo tee -a /etc/hosts
 ```
 
 {% info_block infoBox %}


### PR DESCRIPTION
backoffice.de.spryker.local for accessing backoffice admin panel. Maybe other languages should be added as well.

## PR Description
Add backoffice.de.spryker.local to /etc/hosts to make it accessible 
TBD

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
