### PR TITLE
Update glue-infrastructure.md

### DIFF
--- a/docs/scos/dev/glue-api-guides/202108.0/glue-infrastructure.md
+++ b/docs/scos/dev/glue-api-guides/202108.0/glue-infrastructure.md
@@ -48,7 +48,7 @@ Upon receiving an API request, the `GlueApplication` module verifies whether the
 
 ![Glue Application Module](https://spryker.s3.eu-central-1.amazonaws.com/docs/Glue+API/Glue+API+Developer+Guides/Glue+Infrastructure/glue-application-module.png)
 
-Upon receiving a request object, the `Resource` module needs to provide it with a valid response. Responses are provided as **API Response Objects**. To build them, `Resource` modules use the `RestApi\Spryker\Glue\Kernel\AbstractFactory::getResourceBuilder()` method which returns the `RestResourceBuilderInterface` objects. The `GlueApplication` Resource module serializes such objects into the response format and then passes them to the requestor.
+Upon receiving a request object, the `Resource` module needs to provide it with a valid response. Responses are provided as **API Response Objects**. To build them, `Resource` modules use the `RestApi\Spryker\Glue\Kernel\AbstractFactory::getResourceBuilder()` method which returns the `RestResourceBuilderInterface` objects. The `GlueApplication` module serializes such objects into the response format and then passes them to the requestor.
 
 ![Glue Application Module](https://spryker.s3.eu-central-1.amazonaws.com/docs/Glue+API/Glue+API+Developer+Guides/Glue+Infrastructure/communication.png)
 


### PR DESCRIPTION
I think that the word "Resource" in this case is redundant and confusing, since there is a difference between `GlueApplication` module and `Resource` modules, and it is the `GlueApplication` that receives the API Response Object from the `Resource` module, serialise it and return to requestor.

## PR Description

TBD

## Checklist
- [x ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
