### PR TITLE
Update glue-infrastructure.md

### DIFF
--- a/docs/scos/dev/glue-api-guides/202108.0/glue-infrastructure.md
+++ b/docs/scos/dev/glue-api-guides/202108.0/glue-infrastructure.md
@@ -438,7 +438,7 @@ For date formatting, [ISO-8601](https://www.iso.org/iso-8601-date-and-time-forma
 
 Example:
 * request: 1985-07-01T01:22:11+02:00
-* in storage and responses: 1985-06-31T11:22:11+00:00
+* in storage and responses: 1985-06-30T23:22:11+00:00
 
 ### Prices
 Prices are always returned both in cents and as an integer.


### PR DESCRIPTION
There are only 30 days in any July on the Planet. Moreover every day contains of 24 hours. That is why request date being converted to UTC timezone (i.e. after subtraction of 2 hours) becomes approx 23 hours, not 11.

## PR Description

TBD

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
