### PR TITLE
Fix store method in HelloWorldStorageDeleter

### DIFF
--- a/docs/scos/dev/back-end-development/data-manipulation/data-publishing/handling-data-with-publish-and-synchronization.md
+++ b/docs/scos/dev/back-end-development/data-manipulation/data-publishing/handling-data-with-publish-and-synchronization.md
@@ -653,16 +653,16 @@ class HelloWorldStorageDeleter implements HelloWorldStorageDeleterInterface
             ->find();
 
         foreach ($messages as $message) {
-            $messageStorageTransfer = new HelloWorldStorageTransfer();
-            $messageStorageTransfer->fromArray($message->toArray(), true);
-            $this->store($message->getIdHelloWorldMessage(), $messageStorageTransfer);
+            $this->delete($message->getIdHelloWorldMessage());
         }
     }
 
     /**
+     * @param int $idMessage
+     *
      * @return void
      */
-    protected function store($idMessage, HelloWorldStorageTransfer $messageStorageTransfer): void
+    protected function delete(int $idMessage): void
     {
         SpyHelloWorldMessageStorageQuery::create()
             ->filterByFkHelloWorldMessage($idMessage)

--- a/docs/scos/dev/back-end-development/data-manipulation/data-publishing/handling-data-with-publish-and-synchronization.md
+++ b/docs/scos/dev/back-end-development/data-manipulation/data-publishing/handling-data-with-publish-and-synchronization.md
@@ -662,7 +662,7 @@ class HelloWorldStorageDeleter implements HelloWorldStorageDeleterInterface
      *
      * @return void
      */
-    protected function delete(int $idMessage): void
+    private function delete(int $idMessage): void
     {
         SpyHelloWorldMessageStorageQuery::create()
             ->filterByFkHelloWorldMessage($idMessage)

--- a/docs/scos/dev/back-end-development/data-manipulation/data-publishing/handling-data-with-publish-and-synchronization.md
+++ b/docs/scos/dev/back-end-development/data-manipulation/data-publishing/handling-data-with-publish-and-synchronization.md
@@ -664,13 +664,9 @@ class HelloWorldStorageDeleter implements HelloWorldStorageDeleterInterface
      */
     protected function store($idMessage, HelloWorldStorageTransfer $messageStorageTransfer): void
     {
-        $messages = SpyHelloWorldMessageStorageQuery::create()
-            ->filterByFkHelloWorldMessage_In($messageIds)
-            ->find();
-
-        foreach ($messages as $message) {
-            $message->delete();
-        }
+        SpyHelloWorldMessageStorageQuery::create()
+            ->filterByFkHelloWorldMessage($idMessage)
+            ->delete();
     }
 }
 ```

--- a/docs/scos/dev/back-end-development/data-manipulation/data-publishing/handling-data-with-publish-and-synchronization.md
+++ b/docs/scos/dev/back-end-development/data-manipulation/data-publishing/handling-data-with-publish-and-synchronization.md
@@ -662,7 +662,7 @@ class HelloWorldStorageDeleter implements HelloWorldStorageDeleterInterface
      *
      * @return void
      */
-    private function delete(int $idMessage): void
+    protected function delete(int $idMessage): void
     {
         SpyHelloWorldMessageStorageQuery::create()
             ->filterByFkHelloWorldMessage($idMessage)


### PR DESCRIPTION
## PR Description

The mentioned code can't even work, because there is no `$messageIds` variable. Looks like we're providing a single id to the `store` method and therefore don't need to iterate at all in that method, because this is already done in the `deleteCollectionByHelloWorldEvents` method.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
