### PR TITLE
Update Confusing Plugin Usage

### DIFF
--- a/docs/scos/dev/feature-integration-guides/202204.0/glue-api/glue-api-product-feature-integration.md
+++ b/docs/scos/dev/feature-integration-guides/202204.0/glue-api/glue-api-product-feature-integration.md
@@ -200,8 +200,8 @@ Activate the following plugins:
 
 | PLUGIN | SPECIFICATION | PREREQUISITES | NAMESPACE |
 | --- | --- | --- | --- |
-| ConcreteProductsByProductConcreteIdsResourceRelationshipPlugin | Adds the `concrete-products` resource as a relationship to the `abstract-products` resource. | None | Spryker\Glue\ProductsRestApi\Plugin\GlueApplication |
-|ProductAbstractByProductAbstractSkuResourceRelationshipPlugin |Adds the `abstract-products` resource as a relationship to the `concrete-products` resource. |None| Spryker\Glue\ProductsRestApi\Plugin\GlueApplication|
+| ConcreteProductsByProductConcreteIdsResourceRelationshipPlugin | Adds the `concrete-products` resource as a relationship to the `concrete-products` resource. | None | Spryker\Glue\ProductsRestApi\Plugin\GlueApplication |
+|ProductAbstractByProductAbstractSkuResourceRelationshipPlugin |Adds the `abstract-products` resource as a relationship to the `abstract-products` resource. |None| Spryker\Glue\ProductsRestApi\Plugin\GlueApplication|
 
 **src/Pyz/Glue/GlueApplication/GlueApplicationDependencyProvider.php**
 
@@ -227,11 +227,11 @@ class GlueApplicationDependencyProvider extends SprykerGlueApplicationDependency
         ResourceRelationshipCollectionInterface $resourceRelationshipCollection
     ): ResourceRelationshipCollectionInterface {
         $resourceRelationshipCollection->addRelationship(
-            ProductsRestApiConfig::RESOURCE_ABSTRACT_PRODUCTS,
+            ProductsRestApiConfig::RESOURCE_CONCRETE_PRODUCTS,
             new ConcreteProductsByProductConcreteIdsResourceRelationshipPlugin()
         );
         $resourceRelationshipCollection->addRelationship(
-            ProductsRestApiConfig::RESOURCE_CONCRETE_PRODUCTS,
+            ProductsRestApiConfig::RESOURCE_ABSTRACT_PRODUCTS,
             new ProductAbstractByProductAbstractSkuResourceRelationshipPlugin()
         );
 


### PR DESCRIPTION
## PR Description

Concrete Data should be included when concrete-products are requested and vice versa with abstract-products
This change should also be made in the demo shops

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
