### PR TITLE
Update rabbitmq-zed.critical-phpamqplib-exception-amqpchannelclosedex…

### DIFF
--- a/docs/scos/dev/troubleshooting/troubleshooting-general-technical-issues/rabbitmq-zed.critical-phpamqplib-exception-amqpchannelclosedexception-channel-connection-is-closed.md
+++ b/docs/scos/dev/troubleshooting/troubleshooting-general-technical-issues/rabbitmq-zed.critical-phpamqplib-exception-amqpchannelclosedexception-channel-connection-is-closed.md
@@ -58,14 +58,15 @@ The exact reason for the error is unknown, but we've noticed that it occurs pred
 We have discovered two options that helped to resolve the error:
 
 **1. Implementing RabbitMQ lazy queues**
-One possible solution can be implementing RabbitMQ lazy queues to reduce RAM usage.
+One possible solution can be implementing RabbitMQ lazy queues to reduce RAM usage. This is already implemented for PaaS customers.
 Configuring RabbitMQ to put messages on disk and load them into memory only when they are needed (lazy queuing) can help. For instructions on how to do this, see the CloudAMQ article [Stopping the stampeding herd problem with lazy queues](https://www.cloudamqp.com/blog/2017-07-05-solving-the-thundering-herd-problem-with-lazy-queues.html).
 
 **2. Adjusting CHUNK_SIZE**
 Using smaller chunk sizes for export and storage sync in RabbitMQ might also help to alleviate the issue. Include the following values in the config file used:
 
 ```
-$config[SynchronizationConstants::EXPORT_MESSAGE_CHUNK_SIZE] = 20000;
-$config[SynchronizationConstants::DEFAULT_SYNC_STORAGE_MESSAGE_CHUNK_SIZE] = 20000;
-$config[SynchronizationConstants::DEFAULT_SYNC_SEARCH_QUEUE_MESSAGE_CHUNK_SIZE] = 20000;
+$config[SynchronizationConstants::EXPORT_MESSAGE_CHUNK_SIZE] = 200;
+$config[SynchronizationConstants::DEFAULT_SYNC_STORAGE_MESSAGE_CHUNK_SIZE] = 200;
+$config[SynchronizationConstants::DEFAULT_SYNC_SEARCH_QUEUE_MESSAGE_CHUNK_SIZE] = 200;
+$config[EventConstants::EVENT_CHUNK] = 200;
 ```


### PR DESCRIPTION
…ception-channel-connection-is-closed.md

Added hint that lazy queues are standard on PaaS. Adjusted values for chunk sizes.

## PR Description

TBD

## Checklist
- [x ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
