### PR TITLE
Update tutorial-testing-and-tdd-spryker-commerce-os.md

### DIFF
--- a/docs/scos/dev/tutorials-and-howtos/introduction-tutorials/tutorial-testing-and-tdd-spryker-commerce-os.md
+++ b/docs/scos/dev/tutorials-and-howtos/introduction-tutorials/tutorial-testing-and-tdd-spryker-commerce-os.md
@@ -24,12 +24,6 @@ redirect_from:
   - /v1/docs/en/t-testing-tdd-scos
 ---
 
-{% info_block infoBox %}
-
-This tutorial is also available on the Spryker Training website. For more information and hands-on exercises, visit the [Spryker Training](https://training.spryker.com/courses/developer-bootcamp) website.
-
-{% endinfo_block %}
-
 This document helps you understand the main concepts of testing with Spryker and see how simple it is to build tests. You will use the *Test-Driven Development (TDD)* approach.
 
 Spryker's testing structure and data handling make it very easy to develop using TDD. You will build a simple module that reverses a string and test it.


### PR DESCRIPTION
The linked training is not available anymore, as has been marked as outdated by the Academy team. It has not been replaced yet. Also, the URL is unavailable. Therefore I propose to remove the info box until a new training has been provided

## PR Description

TBD

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
