### PR TITLE
Makes line-size limit in hosts file for windows users more highlighted

### DIFF
--- a/docs/scos/dev/setup/installing-spryker-with-docker/installation-guides/installing-in-demo-mode-on-windows.md
+++ b/docs/scos/dev/setup/installing-spryker-with-docker/installation-guides/installing-in-demo-mode-on-windows.md
@@ -86,10 +86,10 @@ docker/sdk bootstrap
 
 {% info_block infoBox "Bootstrap" %}
 
-Once you finish the setup, you don't need to run `bootstrap` to start the instance. You only need to run it after:
+Once you finish the setup, you don't need to run `bootstrap` to start the instance. You only need to run it after the following takes place:
 
-* Docker SDK version update
-* Deploy file update
+* Docker SDK version update.
+* Deploy file update.
 
 {% endinfo_block %}
 
@@ -117,7 +117,7 @@ Once you finish the setup, you don't need to run `bootstrap` to start the instan
 
     {% endinfo_block %}
 
-    9. Select **File** > **Save**.
+    9. Select **File > Save**.
     10. Close the file.
 
 10. Once the job finishes, build and start the instance:

--- a/docs/scos/dev/setup/installing-spryker-with-docker/installation-guides/installing-in-demo-mode-on-windows.md
+++ b/docs/scos/dev/setup/installing-spryker-with-docker/installation-guides/installing-in-demo-mode-on-windows.md
@@ -84,22 +84,16 @@ sudo usermod -aG docker $USER
 docker/sdk bootstrap
 ```
 
-{% info_block warningBox "Bootstrap" %}
+{% info_block infoBox "Bootstrap" %}
 
 Once you finish the setup, you don't need to run `bootstrap` to start the instance. You only need to run it after:
 
-* Docker SDK version update;
-* Deploy file update.
+* Docker SDK version update
+* Deploy file update
 
 {% endinfo_block %}
 
-9. Once the job finishes, build and start the instance:
-
-```shell
-docker/sdk up
-```
-
-10. Update the `hosts` file:
+9. Update the `hosts` file:
     1. Open the Start menu.
     2. In the search field, enter `Notepad`.
     3. Right-click *Notepad* and select **Run as administrator**.
@@ -111,7 +105,10 @@ docker/sdk up
     8. Add the following line into the file:
 
     ```text
-    127.0.0.1   backend-api.at.spryker.local backend-api.de.spryker.local backend-api.us.spryker.local backend-gateway.at.spryker.local backend-gateway.de.spryker.local backend-gateway.us.spryker.local backoffice.at.spryker.local backoffice.de.spryker.local backoffice.us.spryker.local glue.at.spryker.local glue.de.spryker.local glue.us.spryker.local mail.spryker.local queue.spryker.local scheduler.spryker.local spryker.local swagger.spryker.local yves.at.spryker.local yves.de.spryker.local yves.us.spryker.local
+    127.0.0.1   spryker.local mail.spryker.local queue.spryker.local scheduler.spryker.local swagger.spryker.local
+    127.0.0.1   backend-api.at.spryker.local backend-api.de.spryker.local backend-api.us.spryker.local backend-gateway.at.spryker.local backend-gateway.de.spryker.local backend-gateway.us.spryker.local
+    127.0.0.1   backoffice.at.spryker.local backoffice.de.spryker.local backoffice.us.spryker.local
+    127.0.0.1   glue.at.spryker.local glue.de.spryker.local glue.us.spryker.local yves.at.spryker.local yves.de.spryker.local yves.us.spryker.local
     ```
 
     {% info_block infoBox %}
@@ -123,8 +120,13 @@ docker/sdk up
     9. Select **File** > **Save**.
     10. Close the file.
 
+10. Once the job finishes, build and start the instance:
 
-{% info_block warningBox %}
+```shell
+docker/sdk up
+```
+
+{% info_block infoBox %}
 
 Depending on the hardware performance, the first project launch can take up to 20 minutes.
 

--- a/docs/scos/dev/setup/installing-spryker-with-docker/installation-guides/installing-in-development-mode-on-windows.md
+++ b/docs/scos/dev/setup/installing-spryker-with-docker/installation-guides/installing-in-development-mode-on-windows.md
@@ -110,8 +110,8 @@ docker/sdk bootstrap deploy.dev.yml
 
 Once you finish the setup, you don't need to run `bootstrap` to start the instance. You only need to run it after the following takes place:
 
-* Docker SDK version update
-* Deploy file update
+* Docker SDK version update.
+* Deploy file update.
 
 {% endinfo_block %}
 
@@ -134,11 +134,11 @@ Once you finish the setup, you don't need to run `bootstrap` to start the instan
 
     {% info_block infoBox %}
 
-To get the list of instructions, you can run `docker/sdk install` after `bootstrap`.
+    To get the list of instructions, you can run `docker/sdk install` after `bootstrap`.
 
     {% endinfo_block %}
 
-    9. Select **File** > **Save**.
+    9. Select **File > Save**.
     10. Close the file.
 
 11. Once the job finishes, build and start the instance:

--- a/docs/scos/dev/setup/installing-spryker-with-docker/installation-guides/installing-in-development-mode-on-windows.md
+++ b/docs/scos/dev/setup/installing-spryker-with-docker/installation-guides/installing-in-development-mode-on-windows.md
@@ -79,19 +79,13 @@ Make sure that you are in the correct folder by running the `pwd` command.
 
 {% endinfo_block %}
 
-6. In `deploy.dev.yml`, define `image:` with the PHP image compatible with the current release of the Demo Shop:
-
-```yaml
-image: spryker/php:7.3-alpine3.12
-```
-
-7. Clone the Docker SDK repository:
+6. Clone the Docker SDK repository:
 
 ```bash
 git clone https://github.com/spryker/docker-sdk.git --single-branch docker
 ```
 
-8. In `{shop_name}/docker/context/php/debug/etc/php/debug.conf.d/69-xdebug.ini`, set `xdebug.remote_host` and `xdebug.client_host` to `host.docker.internal`:
+7. In `{shop_name}/docker/context/php/debug/etc/php/debug.conf.d/69-xdebug.ini`, set `xdebug.remote_host` and `xdebug.client_host` to `host.docker.internal`:
 
 ```text
 ...
@@ -100,25 +94,28 @@ xdebug.remote_host=host.docker.internal
 xdebug.client_host=host.docker.internal
 ```
 
-9. Add your user to the `docker` group:
+8. Add your user to the `docker` group:
 
 ```bash
 sudo usermod -aG docker $USER
 ```
 
-10. Bootstrap local docker setup:
+9. Bootstrap local docker setup:
 
 ```bash
 docker/sdk bootstrap deploy.dev.yml
 ```
 
-{% info_block warningBox "Bootstrap" %}
+{% info_block infoBox "Bootstrap" %}
 
-Once you finish the setup, you don't need to run `bootstrap` to start the instance. You only need to run it after you update the Docker SDK or the deploy file.
+Once you finish the setup, you don't need to run `bootstrap` to start the instance. You only need to run it after:
+
+* Docker SDK version update
+* Deploy file update
 
 {% endinfo_block %}
 
-11. Update the `hosts` file:
+10. Update the `hosts` file:
     1. Open the Start menu.
     2. In the search field, enter `Notepad`.
     3. Right-click *Notepad* and select **Run as administrator**.
@@ -129,28 +126,28 @@ Once you finish the setup, you don't need to run `bootstrap` to start the instan
     The hosts file opens in the drop-down.
     8. Follow the installation instructions in the white box from the `docker/sdk bootstrap` command execution results to prepare the environment.
 
+    {% info_block warningBox "Warning" %}
+
+    **It is not recommended to exceed 10 hostnames per line** on Windows machines. Split a long line into multiple lines if necessary.
+
+    {% endinfo_block %}
+
     {% info_block infoBox %}
 
     You can run `docker/sdk install` after `bootstrap` to get the list of the instructions.
 
     {% endinfo_block %}
 
-    {% info_block warningBox "Warning" %}
-
-    Some versions of Windows have a limitation of the number of hostnames per line. It is recommended not to exceed 10 hostnames per line. Split a long line into multiple lines if necessary.
-
-    {% endinfo_block %}
-
     9. Select **File** > **Save**.
     10. Close the file.
 
-12. Once the job finishes, build and start the instance:
+11. Once the job finishes, build and start the instance:
 
 ```bash
 docker/sdk up
 ```
 
-{% info_block warningBox %}
+{% info_block infoBox %}
 
 Depending on the hardware performance, the first project launch can take up to 20 minutes.
 

--- a/docs/scos/dev/setup/installing-spryker-with-docker/installation-guides/installing-in-development-mode-on-windows.md
+++ b/docs/scos/dev/setup/installing-spryker-with-docker/installation-guides/installing-in-development-mode-on-windows.md
@@ -108,7 +108,7 @@ docker/sdk bootstrap deploy.dev.yml
 
 {% info_block infoBox "Bootstrap" %}
 
-Once you finish the setup, you don't need to run `bootstrap` to start the instance. You only need to run it after:
+Once you finish the setup, you don't need to run `bootstrap` to start the instance. You only need to run it after the following takes place:
 
 * Docker SDK version update
 * Deploy file update
@@ -128,13 +128,13 @@ Once you finish the setup, you don't need to run `bootstrap` to start the instan
 
     {% info_block warningBox "Warning" %}
 
-    **It is not recommended to exceed 10 hostnames per line** on Windows machines. Split a long line into multiple lines if necessary.
+    *It is not recommended to exceed 10 hostnames per line* on Windows machines. Split a long line into multiple lines if necessary.
 
     {% endinfo_block %}
 
     {% info_block infoBox %}
 
-    You can run `docker/sdk install` after `bootstrap` to get the list of the instructions.
+To get the list of instructions, you can run `docker/sdk install` after `bootstrap`.
 
     {% endinfo_block %}
 


### PR DESCRIPTION
## PR Description

Problem statement: Several users did oversee the hint for the "hostnames per line" limitation.

The adjustment includes the following:
- changed order of "hostnames per line"-limitation-hint
- made some warning to notices
- changed order of hosts-file adjustment to after bootstrap-section
- applied the rule of max. 10 hostnames per file for demo-mode

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
