### PR TITLE
Update task.yaml with missing version param

### DIFF
--- a/docs/sdk/dev/extend-the-sdk.md
+++ b/docs/sdk/dev/extend-the-sdk.md
@@ -38,6 +38,7 @@ help: string|null #e.g: Fix codestyle violations, lorem ipsum, etc.
 stage: string #e.g.: build
 command: string #e.g.: php %project_dir%/vendor/bin/phpcs -f --standard=%project_dir%/vendor/spryker/code-sniffer/Spryker/ruleset.xml %module_dir%
 type: string #e.g.: local_cli
+version: string #e.g.: 1.0.0
 placeholders:
 - name: string #e.g.: %project_dir%
   valueResolver: string #e.g.: PROJECT_DIR, mapping to a value resolver with id PROJECT_DIR or  a FQCN


### PR DESCRIPTION
After downloading the latest version of the docker-sdk cli `0.6.4` and following the steps for extending with a new task defined in YAML format I got the following error due to incomplete documentation (there is no version in the YAML configuration template in this docs).

Command:
`spryker-sdk sdk:update:all`

Error:
```
The child config "version" under "generate:gluer-api" must be configured.
```

## PR Description

TBD

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
