### PR TITLE
Issue found on placeholders syntax

### DIFF
--- a/docs/sdk/dev/extend-the-sdk.md
+++ b/docs/sdk/dev/extend-the-sdk.md
@@ -40,7 +40,7 @@ command: string #e.g.: php %project_dir%/vendor/bin/phpcs -f --standard=%project
 type: string #e.g.: local_cli
 placeholders:
 - name: string #e.g.: %project_dir%
-  valueResolver: string #e.g.: PROJECT_DIR, mapping to a value resolver with id PROJECT_DIR or  a FQCN
+  value_resolver: string #e.g.: PROJECT_DIR, mapping to a value resolver with id PROJECT_DIR or  a FQCN
   optional: bool
 ```
 


### PR DESCRIPTION
If the task definition task template is used with the latest spryker-sdk version `0.6.4` there is an error in this documentation regarding the placeholders syntaxt.

Command:
`sdk:update:all`

Error:
```
Unrecognized option "valueResolver" under "generate:glue-api.placeholders.0". Did you mean "value_resolver"?
```

## PR Description

TBD

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
