### PR TITLE
Add m1 mac jekyll install steps

### DIFF
--- a/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
+++ b/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
@@ -28,7 +28,13 @@ We use [Jekyll](https://jekyllrb.com/) to build the Spryker documentation site. 
 
 ## Prerequisites
 
-Before you begin, install the following:
+To use Jekyll, you also need to install the following:
+
+{% info_block infoBox "MacOS" %}
+
+MacOS users should _not_ install these until beginning the [Install Jekyll on MacOS](#install-jekyll-on-macos) process below. 
+
+{% endinfo_block %}
 
 * [Ruby](https://www.ruby-lang.org/en/downloads/) version 2.4.0 or higher, including all development headers. To check your version, run `ruby -v`.
 * [RubyGems](https://rubygems.org/pages/download), the latest version. To check your RubyGems version, run `gem -v`.
@@ -40,7 +46,48 @@ Depending on your operating system, follow the Jekyll installation guides below.
 
 ### Install Jekyll on MacOS
 
-To install Jekyll on MacOS:
+{% info_block infoBox "MacOS" %}
+
+The installation process is different depending whether you are using a Mac with an Intel processor or a Mac with an Apple Silicon M1 chip. To find out whether you have an Intel or an Silicon M1 Mac, click the **Apple** menu and choose **About This Mac**.
+
+	•	Silicon Macs with the M1 processor show an item labeled _Chip_ followed by the name of the Apple chip.
+	•	Intel-based Macs show an item labeled _Processor_ followed by the name and/or model number of the Intel processor.
+
+{% endinfo_block %}
+
+On a **MacBook with the M1 processor**, to install Jekyll on MacOS:
+
+{% info_block warningBox "Open Terminal using Rosetta" %}
+
+First, make sure your Terminal is opened with Rosetta 2, by following the instructions here. Rosetta is a translation layer that enables older non-native Intel x86 apps, including Homebrew, to run on new Apple Silicon Macs. 
+
+To open your terminal using Rosetta:
+	1.	Open a Finder window.
+	2.	In Applications, locate Terminal.
+	3.	Right click on **Terminal** and select **Get Info**. 
+	4.	Make sure _Open using Rosetta_ is checked. 
+  
+{% endinfo_block %}
+
+#### 1. Install Homebrew
+
+Homebrew is a package manager for macOS (because by default, Mac doesn’t have a package manager). You'll use Homebrew to install Ruby in the next step. Additionally, when you install Homebrew, Xcode command line tools and GCC are also installed automatically. 
+
+To install Homebrew: 
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
+On MacOS on M1 processor, Homebrew files are installed into the /opt/homebrew folder. Because this folder is not part of the default $PATH, you need to follow the next steps that Homebrew includes at the end of the installation output, to add Homebrew to your PATH. In the example below, the actual username is replaced by _username_ in italics:  /Users/_username_/.zprofile
+
+```bash
+==> Next steps:
+- Run these three commands in your terminal to add Homebrew to your PATH:
+    echo '# Set PATH, MANPATH, etc., for Homebrew.' >> /Users/_username_/.zprofile
+    echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> /Users/_username_/.zprofile
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+
+On a **MacBook with the M1 processor**, to install Jekyll on MacOS:
 
 #### 1. Install command line tools
 To compile native extensions, install the command line tools:

--- a/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
+++ b/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
@@ -103,7 +103,7 @@ To add Homebrew, paste this text into the .zprofile file open in your terminal:
 # Set PATH, MANPATH, etc., for Homebrew.
 eval "$(/opt/homebrew/bin/brew shellenv)"
 ```
-Click **control o** to save the updated .zprofile file. Then click **control x** to exit out of the .zprofile file.
+To save the updated .zprofile file, click **control o**. Then, to exit the .zprofile file, click **control x**.
 
 {% endinfo_block %}
 

--- a/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
+++ b/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
@@ -26,21 +26,7 @@ We use [Jekyll](https://jekyllrb.com/) to build the Spryker documentation site. 
 2. Set up the documentation site locally
 3. Run the documentation site locally
 
-## Prerequisites
 
-To use Jekyll, you also need to install the following:
-
-* [Ruby](https://www.ruby-lang.org/en/downloads/) version 2.4.0 or higher, including all development headers. To check your version, run `ruby -v`.
-* [RubyGems](https://rubygems.org/pages/download), the latest version. To check your RubyGems version, run `gem -v`.
-* [GCC](https://gcc.gnu.org/install/) and [Make](https://www.gnu.org/software/make/). To check your GCC version, run `gcc -v,g++ -v`, for Make version run `make -v`.
-
-
-{% info_block warningBox "MacOS" %}
-
-If you are using MacOS, we recommend you do **not** install these prerequisites before you begin. Depending on your Mac processor and your previously installed applications, installing these before reading the instructions below may cause your installation to fail.
-
-{% endinfo_block %}
-  
 ## Install Jekyll 
 
 Depending on your operating system, follow the Jekyll installation guides below.
@@ -68,7 +54,7 @@ On either an M1 or an Intel Mac, follow the steps below to install Jekyll. M1-sp
 
 #### 1. Install Homebrew
 
-Homebrew is a package manager for macOS because by default, Mac doesn’t have a package manager. You use Homebrew to install Ruby in the next step. Additionally, when you install Homebrew, Xcode command line tools and GCC are also installed automatically. 
+Homebrew is a package manager for macOS because by default Mac doesn’t have a package manager. You use Homebrew to install Ruby in the next step. Additionally, when you install Homebrew, Xcode command line tools and GCC are also installed automatically. 
 
 To install Homebrew, follow these steps: 
 ```bash
@@ -158,6 +144,16 @@ ruby -v
     ```bash
     echo 'export PATH="$HOME/.gem/ruby/X.X.0/bin:$PATH"' >> ~/.bash_profile
     ```
+    
+## Install Jekyll on Windows, Ubuntu, or Other Linux systems – Prerequisites
+
+To use Jekyll, you also need to install the following:
+
+* [Ruby](https://www.ruby-lang.org/en/downloads/) version 2.4.0 or higher, including all development headers. To check your version, run `ruby -v`.
+* [RubyGems](https://rubygems.org/pages/download), the latest version. To check your RubyGems version, run `gem -v`.
+* [GCC](https://gcc.gnu.org/install/) and [Make](https://www.gnu.org/software/make/). To check your GCC version, run `gcc -v,g++ -v`, for Make version run `make -v`.
+
+  
 ### Install Jekyll on Windows
 
 To install Jekyll on Windows, follow the [official Jekyll on Windows documentation](https://jekyllrb.com/docs/installation/windows/).

--- a/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
+++ b/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
@@ -75,7 +75,7 @@ On either an M1 or an Intel Mac, follow the steps below to install Jekyll. M1-sp
 
 Homebrew is a package manager for macOS (because by default, Mac doesn’t have a package manager). You use Homebrew to install Ruby in the next step. Additionally, when you install Homebrew, Xcode command line tools and GCC are also installed automatically. 
 
-To install Homebrew: 
+To install Homebrew, follow these steps: 
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```

--- a/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
+++ b/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
@@ -61,7 +61,7 @@ The installation process is different depending whether you are using a Mac with
 {% info_block warningBox "MacOS on M1 processor – Open Terminal using Rosetta" %}
 
 On a **MacBook with the M1 processor**, make sure your Terminal is opened with Rosetta 2, by following the instructions here. Rosetta is a translation layer that enables non-native Intel x86 apps, including Homebrew, to run on Apple Silicon Macs. 
-To open your terminal using Rosetta:
+To open your terminal using Rosetta, follow these steps:
 1.	Open a Finder window.
 2.	In Applications, locate Terminal.
 3.	Right click on **Terminal** and select **Get Info**. 

--- a/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
+++ b/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
@@ -63,7 +63,7 @@ The installation process is different depending whether you are using a Mac with
 On a **MacBook with the M1 processor**, make sure your Terminal is opened with Rosetta 2, by following the instructions here. Rosetta is a translation layer that enables non-native Intel x86 apps, including Homebrew, to run on Apple Silicon Macs. 
 To open your terminal using Rosetta, follow these steps:
 1.	Open a Finder window.
-2.	In Applications, locate Terminal.
+2.	In _Applications_, locate _Terminal_.
 3.	Right click on **Terminal** and select **Get Info**. 
 4.	Make sure _Open using Rosetta_ is checked. 
   

--- a/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
+++ b/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
@@ -30,15 +30,17 @@ We use [Jekyll](https://jekyllrb.com/) to build the Spryker documentation site. 
 
 To use Jekyll, you also need to install the following:
 
-{% info_block infoBox "MacOS" %}
-
-MacOS users should _not_ install these until beginning the [Install Jekyll on MacOS](#install-jekyll-on-macos) process below. 
-
-{% endinfo_block %}
 
 * [Ruby](https://www.ruby-lang.org/en/downloads/) version 2.4.0 or higher, including all development headers. To check your version, run `ruby -v`.
 * [RubyGems](https://rubygems.org/pages/download), the latest version. To check your RubyGems version, run `gem -v`.
 * [GCC](https://gcc.gnu.org/install/) and [Make](https://www.gnu.org/software/make/). To check your GCC version, run `gcc -v,g++ -v`, for Make version run `make -v`.
+
+
+{% info_block infoBox "MacOS" %}
+
+If you are using MacOS, we recommend you do not install these prerequisites before you begin. Depending on your Mac processor and your previously installed applications, installing these before reading the instructions below may cause your installation to fail.
+
+{% endinfo_block %}
   
 ## Install Jekyll 
 
@@ -46,28 +48,29 @@ Depending on your operating system, follow the Jekyll installation guides below.
 
 ### Install Jekyll on MacOS
 
-{% info_block infoBox "MacOS" %}
+{% info_block infoBox "Determine Your Mac's Processor Type" %}
 
-The installation process is different depending whether you are using a Mac with an Intel processor or a Mac with an Apple Silicon M1 chip. To find out whether you have an Intel or an Silicon M1 Mac, click the **Apple** menu and choose **About This Mac**.
+The installation process is different depending whether you are using a Mac with an Intel processor or with an Apple Silicon M1 chip. To find out whether you have an Intel or a Silicon M1 Mac, click the **Apple** menu and choose **About This Mac**.
 
-	•	Silicon Macs with the M1 processor show an item labeled _Chip_ followed by the name of the Apple chip.
-	•	Intel-based Macs show an item labeled _Processor_ followed by the name and/or model number of the Intel processor.
+- Silicon Macs with the M1 processor show an item labeled _Chip_ followed by the name of the Apple chip.
+
+- Intel-based Macs show an item labeled _Processor_ followed by the name and/or model number of the Intel processor.
 
 {% endinfo_block %}
 
-On a **MacBook with the M1 processor**, to install Jekyll on MacOS:
 
-{% info_block warningBox "Open Terminal using Rosetta" %}
+{% info_block warningBox "On M1 Macs, Open Terminal using Rosetta" %}
 
-First, make sure your Terminal is opened with Rosetta 2, by following the instructions here. Rosetta is a translation layer that enables older non-native Intel x86 apps, including Homebrew, to run on new Apple Silicon Macs. 
-
+On a **MacBook with the M1 processor**, make sure your Terminal is opened with Rosetta 2, by following the instructions here. Rosetta is a translation layer that enables non-native Intel x86 apps, including Homebrew, to run on Apple Silicon Macs. 
 To open your terminal using Rosetta:
-	1.	Open a Finder window.
-	2.	In Applications, locate Terminal.
-	3.	Right click on **Terminal** and select **Get Info**. 
-	4.	Make sure _Open using Rosetta_ is checked. 
+1.	Open a Finder window.
+2.	In Applications, locate Terminal.
+3.	Right click on **Terminal** and select **Get Info**. 
+4.	Make sure _Open using Rosetta_ is checked. 
   
 {% endinfo_block %}
+
+On either an M1 or an Intel Mac, follow the steps below to install Jekyll. M1-specific instructions appear as notes wherever necessary.  
 
 #### 1. Install Homebrew
 
@@ -77,8 +80,11 @@ To install Homebrew:
 ```bash
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 ```
+{% info_block infoBox "MacOS on M1 processor" %}
 
-On MacOS on M1 processor, Homebrew files are installed into the /opt/homebrew folder. Because this folder is not part of the default $PATH, you need to follow the next steps that Homebrew includes at the end of the installation output, to add Homebrew to your PATH. In the example below, the actual username is replaced by _username_ in italics:  /Users/_username_/.zprofile
+On MacOS on M1 processor, Homebrew files are installed into the /opt/homebrew folder. Because this folder is not part of the default $PATH, you need to follow the next steps that Homebrew includes at the end of the installation output to add Homebrew to your PATH. In the example below, your actual username is replaced by _username_ in italics:  /Users/_username_/.zprofile
+
+{% endinfo_block %}
 
 ```bash
 ==> Next steps:
@@ -86,38 +92,50 @@ On MacOS on M1 processor, Homebrew files are installed into the /opt/homebrew 
     echo '# Set PATH, MANPATH, etc., for Homebrew.' >> /Users/_username_/.zprofile
     echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> /Users/_username_/.zprofile
     eval "$(/opt/homebrew/bin/brew shellenv)"
-
-On a **MacBook with the M1 processor**, to install Jekyll on MacOS:
-
-#### 1. Install command line tools
-To compile native extensions, install the command line tools:
-
-```bash
-xcode-select --install
 ```
 
-#### 2. Install Ruby
+Alternately, or if you have problems using these commands to update your PATH, you can add Homebrew to your .zprofile file. First, run:
+```bash
+nano ~/.zprofile
+```
+
+If the profile file has not yet been created on your system, this command creates a new one. If the file already exists, this command opens it, and you can then edit it to add Homebrew.
+
+Paste this text into the .zprofile file open in your terminal:
+```bash
+# Set PATH, MANPATH, etc., for Homebrew.
+eval "$(/opt/homebrew/bin/brew shellenv)"
+```
+
+#### 2. Install Make
+
+```bash
+brew install make
+``` 
+
+#### 3. Install Ruby
 Check your current Ruby version:
 
 ```bash
 ruby -v
 ```
-If Ruby is not installed or the version is below 2.4.0, do the following: 
+{% info_block infoBox "Don't Use System Ruby" %}
 
- 1. Install Homebrew:
-```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-```
-2. Install Ruby:   
+You should not use the Ruby version that came pre-installed with your Mac. (Apple includes an older version of Ruby on macOS for compatibility with legacy software.) It can’t be updated because Apple restricts access to it.) 
+
+{% endinfo_block %}
+
+If you have not yet installed a later Ruby version, do the following, install Ruby: 
+ 
 ```bash
 brew install ruby
 ```
-3. Add the brew Ruby and gems path to your Shell configuration:
-    1. Check what Shell you are using:
+Add the brew Ruby and gems path to your Shell configuration:
+1. Check what Shell you are using:
     ```
     echo $SHELL
     ```
-    2. Add the path using one of the following commands:
+2. Add the path using one of the following commands:
         * Zsh:
         ```bash
         echo 'export PATH="/usr/local/opt/ruby/bin:/usr/local/lib/ruby/gems/3.0.0/bin:$PATH"' >> ~/.zshrc

--- a/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
+++ b/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
@@ -47,20 +47,15 @@ Depending on your operating system, follow the Jekyll installation guides below.
 
 ### Install Jekyll on MacOS
 
-{% info_block infoBox "Determine Your Mac's Processor Type" %}
-
 The installation process is different depending whether you are using a Mac with an Intel processor or with a Silicon M1 chip. To find out whether you have an Intel or a Silicon M1 Mac, click the **Apple** menu and choose **About This Mac**.
 
 * Silicon Macs with the M1 processor show an item labeled _Chip_ followed by the name of the Apple chip.
 
 * Intel-based Macs show an item labeled _Processor_ followed by the name and/or model number of the Intel processor.
 
-{% endinfo_block %}
-
-
 {% info_block warningBox "MacOS on M1 processor – Open Terminal using Rosetta" %}
 
-On a **MacBook with the M1 processor**, make sure your Terminal is opened with Rosetta 2, by following the instructions here. Rosetta is a translation layer that enables non-native Intel x86 apps, including Homebrew, to run on Apple Silicon Macs. 
+On a MacBook with the M1 processor, make sure your Terminal is opened with Rosetta 2, by following the instructions here. Rosetta is a translation layer that enables non-native Intel x86 apps, including Homebrew, to run on Apple Silicon Macs. 
 To open your terminal using Rosetta, follow these steps:
 1.	Open a _Finder_ window.
 2.	In _Applications_, locate _Terminal_.
@@ -73,7 +68,7 @@ On either an M1 or an Intel Mac, follow the steps below to install Jekyll. M1-sp
 
 #### 1. Install Homebrew
 
-Homebrew is a package manager for macOS (because by default, Mac doesn’t have a package manager). You use Homebrew to install Ruby in the next step. Additionally, when you install Homebrew, Xcode command line tools and GCC are also installed automatically. 
+Homebrew is a package manager for macOS because by default, Mac doesn’t have a package manager. You use Homebrew to install Ruby in the next step. Additionally, when you install Homebrew, Xcode command line tools and GCC are also installed automatically. 
 
 To install Homebrew, follow these steps: 
 ```bash
@@ -121,7 +116,7 @@ ruby -v
 ```
 {% info_block infoBox "Don't use system Ruby" %}
 
-You should not use the Ruby version that came pre-installed with your Mac. (Apple includes an older, non-updatable version of Ruby on macOS for compatibility with legacy software.)
+You should not use the Ruby version that came pre-installed with your Mac. Apple includes an older, non-updatable version of Ruby on macOS for compatibility with legacy software.
 
 {% endinfo_block %}
 

--- a/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
+++ b/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
@@ -145,24 +145,26 @@ ruby -v
     echo 'export PATH="$HOME/.gem/ruby/X.X.0/bin:$PATH"' >> ~/.bash_profile
     ```
     
-## Install Jekyll on Windows, Ubuntu, or Other Linux systems – Prerequisites
+### Install Jekyll on Windows, Ubuntu, or other Linux systems 
 
-To use Jekyll, you also need to install the following:
+#### Prerequisites
+
+To use Jekyll on Windows, Ubuntu, or other Linux systems, you also need to install the following:
 
 * [Ruby](https://www.ruby-lang.org/en/downloads/) version 2.4.0 or higher, including all development headers. To check your version, run `ruby -v`.
 * [RubyGems](https://rubygems.org/pages/download), the latest version. To check your RubyGems version, run `gem -v`.
 * [GCC](https://gcc.gnu.org/install/) and [Make](https://www.gnu.org/software/make/). To check your GCC version, run `gcc -v,g++ -v`, for Make version run `make -v`.
 
   
-### Install Jekyll on Windows
+#### Install Jekyll on Windows
 
 To install Jekyll on Windows, follow the [official Jekyll on Windows documentation](https://jekyllrb.com/docs/installation/windows/).
 
-### Install Jekyll on Ubuntu
+#### Install Jekyll on Ubuntu
 
 To install Jekyll on Ubuntu, follow the [official Jekyll on Ubuntu documentation](https://jekyllrb.com/docs/installation/ubuntu/).
 
-### Other Linux systems
+#### Other Linux systems
 
 To install Jekyll on other Linux systems, follow the [official Jekyll on Linux documentation](https://jekyllrb.com/docs/installation/other-linux/).
 

--- a/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
+++ b/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
@@ -62,7 +62,7 @@ The installation process is different depending whether you are using a Mac with
 
 On a **MacBook with the M1 processor**, make sure your Terminal is opened with Rosetta 2, by following the instructions here. Rosetta is a translation layer that enables non-native Intel x86 apps, including Homebrew, to run on Apple Silicon Macs. 
 To open your terminal using Rosetta, follow these steps:
-1.	Open a Finder window.
+1.	Open a _Finder_ window.
 2.	In _Applications_, locate _Terminal_.
 3.	Right click on **Terminal** and select **Get Info**. 
 4.	Make sure _Open using Rosetta_ is checked. 

--- a/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
+++ b/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
@@ -125,7 +125,7 @@ You should not use the Ruby version that came pre-installed with your Mac. (Appl
 
 {% endinfo_block %}
 
-If you have not yet installed a later Ruby version, do the following, install Ruby: 
+If you have not yet installed a recent Ruby version, do the following, install Ruby: 
  
 ```bash
 brew install ruby

--- a/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
+++ b/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
@@ -119,7 +119,7 @@ Check your current Ruby version:
 ```bash
 ruby -v
 ```
-{% info_block infoBox "Don't Use System Ruby" %}
+{% info_block infoBox "Don't use system Ruby" %}
 
 You should not use the Ruby version that came pre-installed with your Mac. (Apple includes an older, non-updatable version of Ruby on macOS for compatibility with legacy software.)
 

--- a/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
+++ b/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
@@ -30,12 +30,6 @@ We use [Jekyll](https://jekyllrb.com/) to build the Spryker documentation site. 
 
 To use Jekyll, you also need to install the following:
 
-{% info_block infoBox "MacOS" %}
-
-MacOS users should _not_ install these until beginning the [Install Jekyll on MacOS](#install-jekyll-on-macos) process below. 
-
-{% endinfo_block %}
-
 * [Ruby](https://www.ruby-lang.org/en/downloads/) version 2.4.0 or higher, including all development headers. To check your version, run `ruby -v`.
 * [RubyGems](https://rubygems.org/pages/download), the latest version. To check your RubyGems version, run `gem -v`.
 * [GCC](https://gcc.gnu.org/install/) and [Make](https://www.gnu.org/software/make/). To check your GCC version, run `gcc -v,g++ -v`, for Make version run `make -v`.
@@ -57,14 +51,14 @@ Depending on your operating system, follow the Jekyll installation guides below.
 
 The installation process is different depending whether you are using a Mac with an Intel processor or with a Silicon M1 chip. To find out whether you have an Intel or a Silicon M1 Mac, click the **Apple** menu and choose **About This Mac**.
 
-- Silicon Macs with the M1 processor show an item labeled _Chip_ followed by the name of the Apple chip.
+* Silicon Macs with the M1 processor show an item labeled _Chip_ followed by the name of the Apple chip.
 
-- Intel-based Macs show an item labeled _Processor_ followed by the name and/or model number of the Intel processor.
+* Intel-based Macs show an item labeled _Processor_ followed by the name and/or model number of the Intel processor.
 
 {% endinfo_block %}
 
 
-{% info_block warningBox "On M1 Macs, Open Terminal using Rosetta" %}
+{% info_block warningBox "MacOS on M1 processor – Open Terminal using Rosetta" %}
 
 On a **MacBook with the M1 processor**, make sure your Terminal is opened with Rosetta 2, by following the instructions here. Rosetta is a translation layer that enables non-native Intel x86 apps, including Homebrew, to run on Apple Silicon Macs. 
 To open your terminal using Rosetta:
@@ -89,8 +83,6 @@ To install Homebrew:
 
 On an M1 Mac, Homebrew files are installed into the /opt/homebrew folder. Because this folder is not part of the default $PATH, you need to follow the next steps that Homebrew includes at the end of the installation output to add Homebrew to your PATH. In the example below, we've replaced your actual username with:  /Users/_username_/.zprofile
 
-{% endinfo_block %}
-
 ```bash
 ==> Next steps:
 - Run these three commands in your terminal to add Homebrew to your PATH:
@@ -111,6 +103,9 @@ To add Homebrew, paste this text into the .zprofile file open in your terminal:
 # Set PATH, MANPATH, etc., for Homebrew.
 eval "$(/opt/homebrew/bin/brew shellenv)"
 ```
+Click **control o** to save the updated .zprofile file. Then click **control x** to exit out of the .zprofile file.
+
+{% endinfo_block %}
 
 #### 2. Install Make
 
@@ -130,17 +125,17 @@ You should not use the Ruby version that came pre-installed with your Mac. (Appl
 
 {% endinfo_block %}
 
-If you have not yet installed a recent Ruby version, do the following, install Ruby: 
+If you have not yet installed a recent Ruby version, install Ruby: 
  
 ```bash
 brew install ruby
 ```
-Add the brew Ruby and gems path to your Shell configuration:
-1. Check what Shell you are using:
+Add the brew Ruby and gems path to your shell configuration:
+1. Check what shell you are using:
     ```
     echo $SHELL
     ```
-2. Add the path using one of the following commands:
+2. Depending which shell you are using, add the path using one of the following commands:
    * Zsh:
         ```bash
         echo 'export PATH="/usr/local/opt/ruby/bin:/usr/local/lib/ruby/gems/3.0.0/bin:$PATH"' >> ~/.zshrc

--- a/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
+++ b/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
@@ -36,9 +36,9 @@ To use Jekyll, you also need to install the following:
 * [GCC](https://gcc.gnu.org/install/) and [Make](https://www.gnu.org/software/make/). To check your GCC version, run `gcc -v,g++ -v`, for Make version run `make -v`.
 
 
-{% info_block infoBox "MacOS" %}
+{% info_block warningBox "MacOS" %}
 
-If you are using MacOS, we recommend you do not install these prerequisites before you begin. Depending on your Mac processor and your previously installed applications, installing these before reading the instructions below may cause your installation to fail.
+If you are using MacOS, we recommend you do **not** install these prerequisites before you begin. Depending on your Mac processor and your previously installed applications, installing these before reading the instructions below may cause your installation to fail.
 
 {% endinfo_block %}
   
@@ -50,7 +50,7 @@ Depending on your operating system, follow the Jekyll installation guides below.
 
 {% info_block infoBox "Determine Your Mac's Processor Type" %}
 
-The installation process is different depending whether you are using a Mac with an Intel processor or with an Apple Silicon M1 chip. To find out whether you have an Intel or a Silicon M1 Mac, click the **Apple** menu and choose **About This Mac**.
+The installation process is different depending whether you are using a Mac with an Intel processor or with a Silicon M1 chip. To find out whether you have an Intel or a Silicon M1 Mac, click the **Apple** menu and choose **About This Mac**.
 
 - Silicon Macs with the M1 processor show an item labeled _Chip_ followed by the name of the Apple chip.
 
@@ -74,7 +74,7 @@ On either an M1 or an Intel Mac, follow the steps below to install Jekyll. M1-sp
 
 #### 1. Install Homebrew
 
-Homebrew is a package manager for macOS (because by default, Mac doesn’t have a package manager). You'll use Homebrew to install Ruby in the next step. Additionally, when you install Homebrew, Xcode command line tools and GCC are also installed automatically. 
+Homebrew is a package manager for macOS (because by default, Mac doesn’t have a package manager). You use Homebrew to install Ruby in the next step. Additionally, when you install Homebrew, Xcode command line tools and GCC are also installed automatically. 
 
 To install Homebrew: 
 ```bash
@@ -82,7 +82,7 @@ To install Homebrew:
 ```
 {% info_block infoBox "MacOS on M1 processor" %}
 
-On MacOS on M1 processor, Homebrew files are installed into the /opt/homebrew folder. Because this folder is not part of the default $PATH, you need to follow the next steps that Homebrew includes at the end of the installation output to add Homebrew to your PATH. In the example below, your actual username is replaced by _username_ in italics:  /Users/_username_/.zprofile
+On an M1 Mac, Homebrew files are installed into the /opt/homebrew folder. Because this folder is not part of the default $PATH, you need to follow the next steps that Homebrew includes at the end of the installation output to add Homebrew to your PATH. In the example below, we've replaced your actual username with:  /Users/_username_/.zprofile
 
 {% endinfo_block %}
 
@@ -99,9 +99,9 @@ Alternately, or if you have problems using these commands to update your PATH, y
 nano ~/.zprofile
 ```
 
-If the profile file has not yet been created on your system, this command creates a new one. If the file already exists, this command opens it, and you can then edit it to add Homebrew.
+If the profile file has not yet been created on your system, this command creates a new one. If the file already exists, this command opens it.
 
-Paste this text into the .zprofile file open in your terminal:
+To add Homebrew, paste this text into the .zprofile file open in your terminal:
 ```bash
 # Set PATH, MANPATH, etc., for Homebrew.
 eval "$(/opt/homebrew/bin/brew shellenv)"
@@ -121,7 +121,7 @@ ruby -v
 ```
 {% info_block infoBox "Don't Use System Ruby" %}
 
-You should not use the Ruby version that came pre-installed with your Mac. (Apple includes an older version of Ruby on macOS for compatibility with legacy software.) It can’t be updated because Apple restricts access to it.) 
+You should not use the Ruby version that came pre-installed with your Mac. (Apple includes an older, non-updatable version of Ruby on macOS for compatibility with legacy software.)
 
 {% endinfo_block %}
 
@@ -136,11 +136,11 @@ Add the brew Ruby and gems path to your Shell configuration:
     echo $SHELL
     ```
 2. Add the path using one of the following commands:
-        * Zsh:
+   * Zsh:
         ```bash
         echo 'export PATH="/usr/local/opt/ruby/bin:/usr/local/lib/ruby/gems/3.0.0/bin:$PATH"' >> ~/.zshrc
         ```
-        * Bash:
+   * Bash:
         ```bash
         echo 'export PATH="/usr/local/opt/ruby/bin:/usr/local/lib/ruby/gems/3.0.0/bin:$PATH"' >> ~/.bash_profile
         ```
@@ -190,7 +190,7 @@ bundle install
 ```
 {% info_block infoBox "MacOS on M1 processor" %}
 
-On a MacBook with the M1 processor, run the following command instead::
+On a MacBook with the M1 processor, run the following command instead:
 
 ```bash
 arch -arch x86_64 bundle install

--- a/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
+++ b/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
@@ -81,7 +81,7 @@ To install Homebrew, follow these steps:
 ```
 {% info_block infoBox "MacOS on M1 processor" %}
 
-On an M1 Mac, Homebrew files are installed into the /opt/homebrew folder. Because this folder is not part of the default $PATH, you need to follow the next steps that Homebrew includes at the end of the installation output to add Homebrew to your PATH. In the example below, we've replaced your actual username with:  /Users/_username_/.zprofile
+On an M1 Mac, Homebrew files are installed into the `/opt/homebrew` folder. Because this folder is not part of the default $PATH, you need to follow the next steps that Homebrew includes at the end of the installation output to add Homebrew to your PATH. In the example below, we've replaced your actual username with:  `/Users/_username_/.zprofile`.
 
 ```bash
 ==> Next steps:

--- a/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
+++ b/docs/scos/user/intro-to-spryker/contribute-to-documentation/build-the-documentation-site.md
@@ -91,7 +91,7 @@ On an M1 Mac, Homebrew files are installed into the `/opt/homebrew` folder. Be
     eval "$(/opt/homebrew/bin/brew shellenv)"
 ```
 
-Alternately, or if you have problems using these commands to update your PATH, you can add Homebrew to your .zprofile file. First, run:
+Alternately, or if you have problems using these commands to update your PATH, you can add Homebrew to your .zprofile file. First, run the following command:
 ```bash
 nano ~/.zprofile
 ```


### PR DESCRIPTION
## PR Description

Added M1 Mac Jekyll install steps. Changed and reordered Mac install steps because Homebrew installs command line tools and GCC automatically.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
