### PR TITLE
Adding information on single locale per chosen key in stores.php

### DIFF
--- a/docs/scos/dev/back-end-development/data-manipulation/datapayload-conversion/multi-language-setup.md
+++ b/docs/scos/dev/back-end-development/data-manipulation/datapayload-conversion/multi-language-setup.md
@@ -51,7 +51,11 @@ For each store, you can define a set of locales, and the first locale is the def
 
 In the previous example, the `en` key is associated with the `en_US` locale.
 
+At this time, Spryker only supports one locale per key (i.e. `en_US` vs `en_GB`). Selecting multiple locales with the same key may result in unexpected behavior.
+
 {% endinfo_block %}
+
+
 
 ### URL routing for stores with multiple locales
 

--- a/docs/scos/dev/technology-partner-guides/201811.0/marketing-and-conversion/customer-communication/personalization-and-cross-selling/econda/exporting-econda-data.md
+++ b/docs/scos/dev/technology-partner-guides/201811.0/marketing-and-conversion/customer-communication/personalization-and-cross-selling/econda/exporting-econda-data.md
@@ -329,3 +329,9 @@ Tracking
 ### Multi-Language support
 If you have multi-language setup, you should provide locale as GET parameter to retrieve the proper version of a CSV file: `curl  http://mysprykershop.com/econda/index/product?locale=en_US`
 You can check `stores.php` file in your project to see what locales you have enabled.
+
+{% info_block infoBox "Info" %}
+
+At this time, Spryker only supports one locale per key (i.e. `en_US` vs `en_GB`). Selecting multiple locales with the same key may result in unexpected behavior.
+
+{% endinfo_block %}

--- a/docs/scos/dev/tutorials-and-howtos/howtos/howto-set-up-stores-with-multiple-locales.md
+++ b/docs/scos/dev/tutorials-and-howtos/howtos/howto-set-up-stores-with-multiple-locales.md
@@ -44,6 +44,12 @@ You can define a set of locales for each store. The first locale is the default 
 
 In the example above, the `en` key is associated with the `en_US` locale.
 
+{% info_block infoBox "Info" %}
+
+At this time, Spryker only supports one locale per key (i.e. `en_US` vs `en_GB`). Selecting multiple locales with the same key may result in unexpected behavior.
+
+{% endinfo_block %}
+
 ## Route URLs for stores with multiple locales
 
 In Yves, the key for the selected locale is contained in the URL; if no key is contained in the URL, the default locale is considered the current one.


### PR DESCRIPTION
## PR Description

An issue was encountered when attempting to use locales with the same key when updating /config/Shared/stores.php. Spryker appears to only support one key per locale at this time.

## Checklist
- [*] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
