### PR TITLE
Fix code snippet in Product Bundles feature integration guide

### DIFF
--- a/_includes/pbc/all/install-features/202204.0/install-the-product-bundles-feature.md
+++ b/_includes/pbc/all/install-features/202204.0/install-the-product-bundles-feature.md
@@ -70,7 +70,7 @@ Set up database schema and transfer objects:
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           name="zed"
           xsi:schemaLocation="spryker:schema-01 https://static.spryker.com/schema-01.xsd"
-          namespace="OrmZedProductBundleStoragePersistence" package="src.Orm.Zed.ProductBundleStorage.Persistence">
+          namespace="Orm\Zed\ProductBundleStorage\Persistence" package="src.Orm.Zed.ProductBundleStorage.Persistence">
 
     <table name="spy_product_bundle_storage">
         <behavior name="synchronization">


### PR DESCRIPTION
## PR Description

Following the [Product Bundle feature integration](https://docs.spryker.com/docs/scos/dev/feature-integration-guides/202204.0/product-bundles-feature-integration.html) causes the following error when trying to execute `console propel:install`.

```
In PropelSchemaMerger.php line 112:
                                                                                                       
  Ambiguous use of name, package and namespace in schema file "spy_product_bundle_storage.schema.xml"  
```

This is caused by the mismatching namespace with [src/Spryker/Zed/ProductBundleStorage/Persistence/Propel/Schema/spy_product_bundle_storage.schema.xml](https://github.com/spryker/product-bundle-storage/blob/1.1.0/src/Spryker/Zed/ProductBundleStorage/Persistence/Propel/Schema/spy_product_bundle_storage.schema.xml).

## Checklist
- [X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
