### PR TITLE
Update approval-process-feature-overview.md

### DIFF
--- a/docs/pbc/all/cart-and-checkout/approval-process-feature-overview.md
+++ b/docs/pbc/all/cart-and-checkout/approval-process-feature-overview.md
@@ -22,7 +22,7 @@ Permissions related to the approval process are configured based on the restrict
 
 Approvers can only approve orders of employees *within their own business unit*.
 
-If there is an employee with a *Buy up to grand total* limit in a business unit that does not have any approvers, then this employee won't see any approvers they could send their order to at the checkout and thus won't be able to proceed with their order. Not even if another business unit of the same company does have an approver, and not even if that other business unit is the direct parent of the employee's business unit.
+If there is an employee with a *Buy up to grand total* limit in a business unit that does not have any approvers, then this employee will not see any approvers they could send their order to at the checkout and thus will not be able to proceed with their order. Not even if another business unit of the same company does have an approver, and not even if that other business unit is the direct parent of the employee's business unit.
 
 {% endinfo_block %}
 

--- a/docs/pbc/all/cart-and-checkout/approval-process-feature-overview.md
+++ b/docs/pbc/all/cart-and-checkout/approval-process-feature-overview.md
@@ -18,6 +18,14 @@ The *Approval Process* feature lets B2B customers have multiple people contribut
 
 Permissions related to the approval process are configured based on the restrictions applied to a [company role](/docs/scos/user/features/{{site.version}}/company-account-feature-overview/company-user-roles-and-permissions-overview.html). Generally, the approval process is initiated when the cart total exceeds a certain amount set in the *Buy up to grand total* permissions. For example, an employee in a company may have to send their order to the manager for approval if the total order cost is above a certain amount. Only after the manager has received the request and approved the order, the employee can proceed to the checkout.
 
+{% info_block warningBox "Note" %}
+
+Approvers can only approve orders of employees *within their own business unit*.
+
+If there is an employee with a *Buy up to grand total* limit in a business unit that does not have any approvers, then this employee won't see any approvers they could send their order to at the checkout and thus won't be able to proceed with their order. Not even if another business unit of the same company does have an approver, and not even if that other business unit is the direct parent of the employee's business unit.
+
+{% endinfo_block %}
+
 When a company user requests approval for their cart, the cart gets locked, and the users can't edit it.
 
 
@@ -45,7 +53,7 @@ For the approval process, you can set specific permissions for the Approver and 
 
 {% info_block warningBox "Note" %}
 
-It is mandatory for the Buyer role to set this permission if you want to use the Approval Process feature in your project.
+It is mandatory to set this permission for the Buyer role if you want to use the Approval Process feature in your project.
 
 {% endinfo_block %}
 


### PR DESCRIPTION
- Added a new note block to make it clear that the approver role is restricted by business unit.
- Edited an existing note block to clarify the meaning, as the original was confusing (it implied that _the Buyer role_ needs to set the permission, when in fact the permission needs to be set _for_ the buyer role.

## PR Description

TBD

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
