### PR TITLE
minor PHP version update

### DIFF
--- a/docs/scos/user/intro-to-spryker/whats-new/php8-as-a-minimum-version-for-all-spryker-projects.md
+++ b/docs/scos/user/intro-to-spryker/whats-new/php8-as-a-minimum-version-for-all-spryker-projects.md
@@ -33,7 +33,7 @@ spryker-sdk/spryk-gui => 0.2.2
 
 2. Change the PHP version in `composer.json`:
 
-`config.platform.php => 8.0`
+`config.platform.php => 8.0.12`
 
 3. Make sure there are no project-specific changes in the following repositories, and remove them from your `composer.json`:
 


### PR DESCRIPTION
## PR Description

With the 8.0 as a version, I get an error
```
roave/better-reflection[5.0.0, ..., 5.10.x-dev] require php ~8.0.12 || ~8.1.0 -> your php version (8.0; overridden via config.platform, actual: 8.0.19) does not satisfy that requirement
```
and the fix shown has resolved the problem.

## Checklist
- [ ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
