### PR TITLE
Fixed example code

### DIFF
--- a/docs/scos/dev/back-end-development/data-manipulation/data-publishing/handle-data-with-publish-and-synchronization.md
+++ b/docs/scos/dev/back-end-development/data-manipulation/data-publishing/handle-data-with-publish-and-synchronization.md
@@ -611,8 +611,13 @@ class HelloWorldStorageWriter implements HelloWorldStorageWriterInterface
      */
     public function writeCollectionByHelloWorldEvents(array $eventTransfers): void
     {
+        $idEntities = [];
+        foreach ($eventTransfers as $eventTransfer) {
+            $idEntities[] = $eventTransfer->getId();
+        }
+
         $messages = SpyHelloWorldMessageQuery::create()
-            ->filterByIdHelloWorldMessage_In($eventTransfers)
+            ->filterByIdHelloWorldMessage_In($idEntities)
             ->find();
 
         foreach ($messages as $message) {
@@ -653,8 +658,13 @@ class HelloWorldStorageDeleter implements HelloWorldStorageDeleterInterface
      */
     public function deleteCollectionByHelloWorldEvents(array $eventTransfers): void
     {
+        $idEntities = [];
+        foreach ($eventTransfers as $eventTransfer) {
+            $idEntities[] = $eventTransfer->getId();
+        }
+
         $messages = SpyHelloWorldMessageQuery::create()
-            ->filterByIdHelloWorldMessage_In($eventTransfers)
+            ->filterByIdHelloWorldMessage_In($idEntities)
             ->find();
 
         foreach ($messages as $message) {


### PR DESCRIPTION
Without this missing part, the example code errors out because the `filterByIdHelloWorldMessage_In` can't handle the array of `EventEntityTransfer`s: it kept trying to put those entire transfer objects into the SQL, which resulted in errors.

## PR Description

TBD

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
