### PR TITLE
Update declaration-of-module-apis-public-and-private.md

### DIFF
--- a/docs/scos/dev/architecture/module-api/declaration-of-module-apis-public-and-private.md
+++ b/docs/scos/dev/architecture/module-api/declaration-of-module-apis-public-and-private.md
@@ -58,9 +58,7 @@ In the Spryker Commerce OS's core, the following is the public API:
 * Search
 * [Storage](/docs/scos/dev/back-end-development/client/use-and-configure-redis-as-a-key-value-storage.html)
 * [Transfer objects](/docs/scos/dev/back-end-development/data-manipulation/data-ingestion/structural-preparations/create-use-and-extend-the-transfer-objects.html)
-* Dependencies to open source components
 * Glossary keys
-* Software design
 
 
 


### PR DESCRIPTION
## PR Description

1. Somehow during [this change](https://github.com/spryker/spryker-docs/pull/836/files#diff-867c27e86d3bb562e3a0005a53004834160c6a46144e8d536921b4d94a4ed71c) we got a complete "**software design**" as a Module API. It's vague and should not be used.
2. If a dependency directly used on a project, it MUST be declared on the project level compose.json. Dependencies to 3rd party components are NOT Module APIs, until these changes are BC with other defined Module APIs. This line is a bad way to move the responsibility of managing components that are used directly on a project to the product team. Until Modules work as expected there is no promise on outgoing module dependencies.



## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
