### PR TITLE
[WIP]Update declaration-of-module-apis-public-and-private.md

### DIFF
--- a/docs/scos/dev/architecture/module-api/declaration-of-module-apis-public-and-private.md
+++ b/docs/scos/dev/architecture/module-api/declaration-of-module-apis-public-and-private.md
@@ -61,6 +61,7 @@ In the Spryker Commerce OS's core, the following is the public API:
 * Dependencies to open source components
 * Glossary keys
 * Software design
+* Symfony App Events
 
 
 


### PR DESCRIPTION
## PR Description

If a module was throwing Symfony Events, stopping doing so can break a project custom behaviour.
Therefore Symfony Events should be considered as SCOS MF Module API.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
