### PR TITLE
add missing redirects

### DIFF
--- a/docs/scos/dev/glue-api-guides/202212.0/old-glue-infrastructure/glue-infrastructure.md
+++ b/docs/scos/dev/glue-api-guides/202212.0/old-glue-infrastructure/glue-infrastructure.md
@@ -16,6 +16,7 @@ redirect_from:
   - /v5/docs/en/glue-infrastructure
   - /docs/scos/dev/concepts/glue-api/glue-infrastructure.html
   - /docs/scos/dev/glue-api-guides/202200.0/glue-infrastructure.html
+  - /docs/scos/dev/glue-api-guides/202212.0/glue-infrastructure.html
 related:
   - title: Authentication and authorization
     link: docs/pbc/all/identity-access-management/page.version/glue-api-authentication-and-authorization.html

--- a/docs/scos/dev/glue-api-guides/202212.0/old-glue-infrastructure/glue-rest-api.md
+++ b/docs/scos/dev/glue-api-guides/202212.0/old-glue-infrastructure/glue-rest-api.md
@@ -10,6 +10,7 @@ redirect_from:
   - /docs/glue-rest-api
   - /docs/en/glue-rest-api
   - /docs/scos/dev/glue-api-guides/202200.0/glue-rest-api.html
+  - /docs/scos/dev/glue-api-guides/202212.0/glue-rest-api.html
   - /api/definition-api.htm
 related:
   - title: Reference information - GlueApplication errors

--- a/docs/scos/dev/glue-api-guides/202212.0/old-glue-infrastructure/handling-concurrent-rest-requests-and-caching-with-entity-tags.md
+++ b/docs/scos/dev/glue-api-guides/202212.0/old-glue-infrastructure/handling-concurrent-rest-requests-and-caching-with-entity-tags.md
@@ -10,6 +10,7 @@ redirect_from:
   - /2021080/docs/en/handling-concurrent-rest-requests-and-caching-with-entity-tags
   - /docs/handling-concurrent-rest-requests-and-caching-with-entity-tags
   - /docs/en/handling-concurrent-rest-requests-and-caching-with-entity-tags
+  - /docs/scos/dev/glue-api-guides/202212.0/handling-concurrent-rest-requests-and-caching-with-entity-tags.html
 related:
   - title: Glue Infrastructure
     link: docs/scos/dev/glue-api-guides/page.version/old-glue-infrastructure/glue-infrastructure.html

--- a/docs/scos/dev/glue-api-guides/202212.0/old-glue-infrastructure/reference-information-glueapplication-errors.md
+++ b/docs/scos/dev/glue-api-guides/202212.0/old-glue-infrastructure/reference-information-glueapplication-errors.md
@@ -11,6 +11,7 @@ redirect_from:
   - /docs/reference-information-glueapplication-errors
   - /docs/en/reference-information-glueapplication-errors
   - /docs/scos/dev/glue-api-guides/202200.0/reference-information-glueapplication-errors.html
+  - /docs/scos/dev/glue-api-guides/202212.0/reference-information-glueapplication-errors.html
 related: 
   - title: Glue REST API
     link: docs/scos/dev/glue-api-guides/page.version/old-glue-infrastructure/glue-rest-api.html

--- a/docs/scos/dev/glue-api-guides/202212.0/old-glue-infrastructure/resolving-search-engine-friendly-urls.md
+++ b/docs/scos/dev/glue-api-guides/202212.0/old-glue-infrastructure/resolving-search-engine-friendly-urls.md
@@ -10,6 +10,7 @@ redirect_from:
   - /2021080/docs/en/resolving-search-engine-friendly-urls
   - /docs/resolving-search-engine-friendly-urls
   - /docs/en/resolving-search-engine-friendly-urls
+  - /docs/scos/dev/glue-api-guides/202212.0/resolving-search-engine-friendly-urls.html
 related:
   - title: Glue API - Spryker Core feature integration
     link: docs/pbc/all/miscellaneous/page.version/install-and-upgrade/install-glue-api/install-the-spryker-core-glue-api.html

--- a/docs/scos/dev/glue-api-guides/202212.0/old-glue-infrastructure/rest-api-b2b-reference.md
+++ b/docs/scos/dev/glue-api-guides/202212.0/old-glue-infrastructure/rest-api-b2b-reference.md
@@ -3,6 +3,8 @@ title: REST API B2B Demo Shop reference
 description: This page provides an exhaustive reference for the REST API endpoints present in the Spryker B2B demo Shop by default with the corresponding parameters and data formats.
 last_updated: May 10, 2022
 template: glue-api-storefront-guide-template
+redirect_from:
+  - /docs/scos/dev/glue-api-guides/202212.0/rest-api-b2b-reference.html
 related: 
   - title: Reference information- GlueApplication errors
     link: docs/scos/dev/glue-api-guides/page.version/old-glue-infrastructure/reference-information-glueapplication-errors.html

--- a/docs/scos/dev/glue-api-guides/202212.0/old-glue-infrastructure/rest-api-b2c-reference.md
+++ b/docs/scos/dev/glue-api-guides/202212.0/old-glue-infrastructure/rest-api-b2c-reference.md
@@ -12,6 +12,7 @@ redirect_from:
   - /docs/en/rest-api-reference
   - /docs/scos/dev/glue-api-guides/202204.0/rest-api-reference.html
   - /docs/scos/dev/glue-api-guides/202200.0/rest-api-reference.html
+  - /docs/scos/dev/glue-api-guides/202212.0/rest-api-b2c-reference.html
 related: 
   - title: Reference information- GlueApplication errors
     link: docs/scos/dev/glue-api-guides/page.version/old-glue-infrastructure/reference-information-glueapplication-errors.html


### PR DESCRIPTION
## PR Description
This PR adds missing redirects to the docs in the `/docs/scos/dev/glue-api-guides/202212.0/old-glue-infrastructure` folder.
Jira task: https://spryker.atlassian.net/browse/DOC-169
TBD

## Checklist
- [ ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
