### PR TITLE
Fixes typo in persistence folder's name

### DIFF
--- a/docs/scos/dev/back-end-development/data-manipulation/data-publishing/handle-data-with-publish-and-synchronization.md
+++ b/docs/scos/dev/back-end-development/data-manipulation/data-publishing/handle-data-with-publish-and-synchronization.md
@@ -511,7 +511,7 @@ To synchronize data with Redis, an intermediate Zed database table is required. 
 
 Follow the steps to create the table:
 
-1. Create the table schema file in `Pyz\Zed\HelloWorldStorage\Persistance\Propel\Schema\spy_hello_world_storage.schema.xml`.
+1. Create the table schema file in `Pyz\Zed\HelloWorldStorage\Persistence\Propel\Schema\spy_hello_world_storage.schema.xml`.
 
 ```xml
 {% raw %}


### PR DESCRIPTION
It fixes a typo in the instructions for the creation of spy_helloworld_message_storage table

## PR Description

TBD

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
