### PR TITLE
Fixes HelloWorldStorageClient $idMessage parameter

### DIFF
--- a/docs/scos/dev/back-end-development/data-manipulation/data-publishing/handle-data-with-publish-and-synchronization.md
+++ b/docs/scos/dev/back-end-development/data-manipulation/data-publishing/handle-data-with-publish-and-synchronization.md
@@ -1050,7 +1050,7 @@ interface HelloWorldStorageClientInterface
      *
      * @return \Generated\Shared\Transfer\HelloWorldStorageTransfer
      */
-    public function getMessageById(int $messageId): HelloWorldStorageTransfer;
+    public function getMessageById(int $idMessage): HelloWorldStorageTransfer;
 }
 ```
 
@@ -1078,7 +1078,7 @@ class HelloWorldStorageClient extends AbstractClient implements HelloWorldStorag
     {
         return $this->getFactory()
             ->createMessageStorageReader()
-            ->getMessageById($messageId);
+            ->getMessageById($idMessage);
     }
 }
 ```


### PR DESCRIPTION
there was $messageId in the interface and $idMessage in the implementation and $messageId passed to the method call, which didn't work. Fixed code so as to have $idMessage as parameter

## PR Description

TBD

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
