### PR TITLE
fix: align package documentation with latest changes

### DIFF
--- a/docs/scos/dev/front-end-development/202307.0/oryx/dependency-injection/dependency-injection-advanced-strategies.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/dependency-injection/dependency-injection-advanced-strategies.md
@@ -5,11 +5,6 @@ template: concept-topic-template
 last_updated: Apr 13, 2023
 ---
 
-{% info_block warningBox %}
-
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 This document describes advanced strategies of using [dependency injection (DI)](/docs/scos/dev/front-end-development/{{page.version}}/oryx/dependency-injection/dependency-injection.html).
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/dependency-injection/dependency-injection-defining-services.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/dependency-injection/dependency-injection-defining-services.md
@@ -5,12 +5,6 @@ template: concept-topic-template
 last_updated: Apr 13, 2023
 ---
 
-{% info_block warningBox %}
-
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
-
 This document describes the conventions we use and recommend for defining services in Oryx.
 
 ## String-based token

--- a/docs/scos/dev/front-end-development/202307.0/oryx/dependency-injection/dependency-injection-providing-services.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/dependency-injection/dependency-injection-providing-services.md
@@ -5,12 +5,6 @@ template: concept-topic-template
 last_updated: Apr 13, 2023
 ---
 
-{% info_block warningBox %}
-
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
-
 To use and inject services, they must be provided in the DI container. Oryx offers several types of providers:
 
 - `ClassProvider<T>`: binds a token to a class constructor.

--- a/docs/scos/dev/front-end-development/202307.0/oryx/dependency-injection/dependency-injection-using-services.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/dependency-injection/dependency-injection-using-services.md
@@ -5,12 +5,6 @@ template: concept-topic-template
 last_updated: Apr 13, 2023
 ---
 
-{% info_block warningBox %}
-
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
-
 There are two primary methods for injecting services and dependencies:
 
 - `inject`: usually used inside services.

--- a/docs/scos/dev/front-end-development/202307.0/oryx/dependency-injection/dependency-injection.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/dependency-injection/dependency-injection.md
@@ -5,11 +5,6 @@ template: concept-topic-template
 last_updated: Apr 13, 2023
 ---
 
-{% info_block warningBox %}
-
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 Dependency injection (DI) is a design pattern that provides loosely-coupled, maintainable, and testable code. It improves modularity, maintainability, testability, and is easily customizable and extensible.
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/dependency-injection/oryx-service-layer.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/dependency-injection/oryx-service-layer.md
@@ -5,12 +5,6 @@ template: concept-topic-template
 last_updated: Apr 13, 2023
 ---
 
-{% info_block warningBox %}
-
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
-
 The service layer in Oryx serves as the foundation for the business logic. The main objective of the service layer is to abstract all the system functionality, including querying backend services, data caching and reloading, state management, and reactivity. Dependency injection (DI) plays a crucial role in achieving this objective.
 
 Furthermore, DI is utilized by many higher-level elements and concepts in Oryx, ranging from adapters and normalizers to HTTP interceptors, authentication, product loading, cart management, and the checkout process.

--- a/docs/scos/dev/front-end-development/202307.0/oryx/oryx-application-orchestration/oryx-application-environment.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/oryx-application-orchestration/oryx-application-environment.md
@@ -4,11 +4,7 @@ description: Environment of the Oryx Application
 template: concept-topic-template
 ---
 
-{% info_block warningBox %}
 
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 `AppEnvironment` represents environment variables that are used in an Oryx application. It's a typesafe global object that can be extended wherever an environment variable is needed for a feature to work properly.
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/oryx-application-orchestration/oryx-application-feature.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/oryx-application-orchestration/oryx-application-feature.md
@@ -4,11 +4,6 @@ description: Feature of the Oryx Application
 template: concept-topic-template
 ---
 
-{% info_block warningBox %}
-
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 `AppFeature` is a higher level collection of lower-level primitives, such as the following:
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/oryx-application-orchestration/oryx-application-orchestration.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/oryx-application-orchestration/oryx-application-orchestration.md
@@ -4,11 +4,6 @@ description: Orchestration of the Oryx Application
 template: concept-topic-template
 ---
 
-{% info_block warningBox %}
-
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 An Oryx application starts with the application orchestration. It lets you bootstrap and configure your application from reusable bits and pieces, such as the following:
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/oryx-application-orchestration/oryx-application-plugins.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/oryx-application-orchestration/oryx-application-plugins.md
@@ -4,11 +4,7 @@ description: Plugins of the Oryx Application
 template: concept-topic-template
 ---
 
-{% info_block warningBox %}
 
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 When you create an Oryx Application with the `appBuilder()` function, it creates an instance of `App`. `App` is a a shell that can be enhanced with custom plugins: `AppPlugin`. Plugins let you extend Oryx core behavior without modifying the core code of the framework.
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/oryx-application-orchestration/oryx-application.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/oryx-application-orchestration/oryx-application.md
@@ -4,11 +4,6 @@ description: App of the Oryx Application
 template: concept-topic-template
 ---
 
-{% info_block warningBox %}
-
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 `App` represents a running Oryx application instance.
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/oryx-boilerplate.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/oryx-boilerplate.md
@@ -5,11 +5,6 @@ last_updated: Apr 3, 2023
 template: concept-topic-template
 ---
 
-{% info_block warningBox %}
-
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 Boilerplate refers to the _template_ code that is used to generate application code which can be further customized. At first sight, changing boilerplate is convenient as the code is at hand, generated in your project repository. However, when upgrading to newer versions of the original code, it becomes challenging. If you customized the boilerplate code and want to reapply a new version of the boilerplate, you have to merge the customizations with the new version during every update. This is a time-consuming and error-prone process that can slow down your development process and increase the risk of bugs.
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/oryx-compositions.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/oryx-compositions.md
@@ -5,11 +5,7 @@ last_updated: June 8, 2023
 template: concept-topic-template
 ---
 
-{% info_block warningBox %}
 
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 Compositions in Oryx are a tool for organizing components and defining their layout. It removes page-specific layout concerns from the component implementation, which makes the components less opinionated and more reusable.
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/oryx-feature-sets.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/oryx-feature-sets.md
@@ -5,11 +5,7 @@ last_updated: May 24, 2023
 template: concept-topic-template
 ---
 
-{% info_block warningBox %}
 
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 A _feature set_ is a group of related features that can be added to an Oryx application with a single reference. Feature sets simplify the process of setting up an application by reducing the amount of [boilerplate code](/docs/scos/dev/front-end-development/{{page.version}}/oryx/oryx-boilerplate.html) required to configure and initialize the application.
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/oryx-packages.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/oryx-packages.md
@@ -7,7 +7,7 @@ template: concept-topic-template
 
 {% info_block warningBox %}
 
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
+Oryx is currently running under an _Early Access Release_. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
 
 {% endinfo_block %}
 
@@ -29,13 +29,13 @@ While the package layering might be irrelevant during your development, it might
 
 The template layer contains packages that can be used as quick starters for demos and projects. Templated packages follow semantic versioning and ensure upgradability. Some packages in the template layer, like presets, are opinionated and might not be used inside your final setup. Their main purpose is to quickly get up and running a standard frontend application.
 
-| PACKAGES                                                                 | LOCATION                                                        |
-| ------------------------------------------------------------------------ | --------------------------------------------------------------- |
-|                                                                          |                                                                 |
-| [Application](https://www.npmjs.com/package/@spryker-oryx/application)   | `@spryker-oryx/oryx-application-orchestration/oryx-application` |
-| [Presets](https://www.npmjs.com/package/@spryker-oryx/oryx-presets.html) | `@spryker-oryx/oryx-presets`                                    |
-| [Labs ](https://www.npmjs.com/package/@spryker-oryx/labs)                | `@spryker-oryx/labs`                                            |
-| [Themes ](https://www.npmjs.com/package/@spryker-oryx/themes)            | `@spryker-oryx/themes`                                          |
+| PACKAGES                                                               | LOCATION                    |
+| ---------------------------------------------------------------------- | --------------------------- |
+|                                                                        |                             |
+| [Application](https://www.npmjs.com/package/@spryker-oryx/application) | `@spryker-oryx/application` |
+| [Presets](https://www.npmjs.com/package/@spryker-oryx/presets)         | `@spryker-oryx/presets`     |
+| [Labs ](https://www.npmjs.com/package/@spryker-oryx/labs)              | `@spryker-oryx/labs`        |
+| [Themes ](https://www.npmjs.com/package/@spryker-oryx/themes)          | `@spryker-oryx/themes`      |
 
 {% info_block infoBox %}
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/oryx-packages.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/oryx-packages.md
@@ -5,11 +5,7 @@ last_updated: Apr 19, 2023
 template: concept-topic-template
 ---
 
-{% info_block warningBox %}
 
-Oryx is currently running under an _Early Access Release_. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 The Oryx code base is [available on Github](https://github.com/spryker/oryx/), and the code is published and distributed as npm packages. [npmjs.com](https://www.npmjs.com/) is a widely used registry of packages. Package managers, like npm, yarn, deno, or bun, are used to install dependencies in a project. The dependencies are typically configured in the [package.json](https://docs.npmjs.com/cli/v9/configuring-npm/package-json) file of an application.
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/oryx-packages.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/oryx-packages.md
@@ -29,13 +29,13 @@ While the package layering might be irrelevant during your development, it might
 
 The template layer contains packages that can be used as quick starters for demos and projects. Templated packages follow semantic versioning and ensure upgradability. Some packages in the template layer, like presets, are opinionated and might not be used inside your final setup. Their main purpose is to quickly get up and running a standard frontend application.
 
-| PACKAGES                                                                 | LOCATION                                                                |
-| ------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
-|                                                                          |                                                                         |
-| [Application](https://www.npmjs.com/package/@spryker-oryx/application)   | `@spryker-oryx/oryx-application-orchestration/oryx-applicationlication` |
-| [Presets](https://www.npmjs.com/package/@spryker-oryx/oryx-presets.html) | `@spryker-oryx/oryx-presets`                                            |
-| [Labs ](https://www.npmjs.com/package/@spryker-oryx/labs)                | `@spryker-oryx/labs`                                                    |
-| [Themes ](https://www.npmjs.com/package/@spryker-oryx/themes)            | `@spryker-oryx/themes`                                                  |
+| PACKAGES                                                                 | LOCATION                                                        |
+| ------------------------------------------------------------------------ | --------------------------------------------------------------- |
+|                                                                          |                                                                 |
+| [Application](https://www.npmjs.com/package/@spryker-oryx/application)   | `@spryker-oryx/oryx-application-orchestration/oryx-application` |
+| [Presets](https://www.npmjs.com/package/@spryker-oryx/oryx-presets.html) | `@spryker-oryx/oryx-presets`                                    |
+| [Labs ](https://www.npmjs.com/package/@spryker-oryx/labs)                | `@spryker-oryx/labs`                                            |
+| [Themes ](https://www.npmjs.com/package/@spryker-oryx/themes)            | `@spryker-oryx/themes`                                          |
 
 {% info_block infoBox %}
 
@@ -49,7 +49,6 @@ Domain packages provide components and service logic for certain domains. Organi
 
 | PACKAGES                                                         | LOCATION                 |
 | ---------------------------------------------------------------- | ------------------------ |
-| [Auth](https://www.npmjs.com/package/@spryker-oryx/auth)         | `@spryker-oryx/auth`     |
 | [Cart](https://www.npmjs.com/package/@spryker-oryx/cart)         | `@spryker-oryx/cart`     |
 | [Checkout](https://www.npmjs.com/package/@spryker-oryx/checkout) | `@spryker-oryx/checkout` |
 | [Content](https://www.npmjs.com/package/@spryker-oryx/content)   | `@spryker-oryx/content`  |
@@ -66,8 +65,10 @@ The platform layer contains the core packages of the Oryx framework. They provid
 
 | PACKAGES                                                                           | LOCATION                          |
 | ---------------------------------------------------------------------------------- | --------------------------------- |
+| [Auth](https://www.npmjs.com/package/@spryker-oryx/auth)                           | `@spryker-oryx/auth`              |
 | [Core](https://www.npmjs.com/package/@spryker-oryx/core)                           | `@spryker-oryx/core`              |
 | [Experience](https://www.npmjs.com/package/@spryker-oryx/experience)               | `@spryker-oryx/experience`        |
+| [Form](https://www.npmjs.com/package/@spryker-oryx/form)                           | `@spryker-oryx/form`              |
 | [I18n](https://www.npmjs.com/package/@spryker-oryx/I18n)                           | `@spryker-oryx/i18n`              |
 | [Indexed-db](https://www.npmjs.com/package/@spryker-oryx/indexed-db)               | `@spryker-oryx/indexed-db`        |
 | [offline](https://www.npmjs.com/package/@spryker-oryx/offline)                     | `@spryker-oryx/offline`           |
@@ -81,6 +82,5 @@ The base layer contains packages that serve as utilities to all layers above. An
 | PACKAGES                                                           | LOCATION                  |
 | ------------------------------------------------------------------ | ------------------------- |
 | [UI](https://www.npmjs.com/package/@spryker-oryx/ui)               | `@spryker-oryx/ui`        |
-| [Form](https://www.npmjs.com/package/@spryker-oryx/form)           | `@spryker-oryx/form`      |
 | [Utilities](https://www.npmjs.com/package/@spryker-oryx/utilities) | `@spryker-oryx/utilities` |
 | [DI](https://www.npmjs.com/package/@spryker-oryx/di)               | `@spryker-oryx/di`        |

--- a/docs/scos/dev/front-end-development/202307.0/oryx/oryx-presets.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/oryx-presets.md
@@ -5,11 +5,6 @@ template: concept-topic-template
 last_updated: Apr 4, 2023
 ---
 
-{% info_block warningBox %}
-
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 The [presets package](https://www.npmjs.com/package/@spryker-oryx/presets) contains standard feature sets and resources that are used to create sample applications without writing [boilerplate](/docs/scos/dev/front-end-development/{{page.version}}/oryx/oryx-boilerplate.html). Presets might be too opinionated to use for a production application, but they let you get started quickly.
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/oryx-routing.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/oryx-routing.md
@@ -5,11 +5,7 @@ template: concept-topic-template
 last_updated: May 25, 2023
 ---
 
-{% info_block warningBox %}
 
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 Routing lets users navigate between different pages and components within an application. This document describes how to set up routing: add `RouterFeature`, render router outlets, and provide routes using [Dependency Injection (DI)](/docs/scos/dev/front-end-development/{{page.version}}/oryx/dependency-injection/dependency-injection.html).
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/oryx-server-side-rendering.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/oryx-server-side-rendering.md
@@ -5,11 +5,7 @@ template: concept-topic-template
 last_updated: June 3, 2023
 ---
 
-{% info_block warningBox %}
 
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 Server-side rendering (SSR), including Static Site Generation (SSG) as a variant, has grown in popularity due to its ability to boost web application performance, facilitate effective Search Engine Optimization (SEO), social sharing, and improve Core Web Vitals (CWV). By delivering pre-rendered HTML from the server or even a  content delivery network (CDN) to the client, SSR and SSG lead to quicker initial page load times, improve user experience (UX), and can significantly improve CWV scores. SSG, in particular, pre-renders HTML at build time, resulting in static HTML, CSS, and JavaScript files that can be served directly from a CDN. It is a useful strategy for sites with content that does not change frequently, and can improve performance, scalability, and security.
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/oryx-supported-browsers.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/oryx-supported-browsers.md
@@ -5,11 +5,6 @@ template: concept-topic-template
 last_updated: May 23, 2023
 ---
 
-{% info_block warningBox %}
-
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 Oryx supports all modern browsers and operating systems.
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/oryx-versioning.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/oryx-versioning.md
@@ -5,11 +5,6 @@ template: concept-topic-template
 last_updated: Mar 3, 2023
 ---
 
-{% info_block warningBox %}
-
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 This document describes the methods used in Oryx to deliver an advanced application development platform while maintaining stability. The goal of implementing versioning methods is to ensure that any upcoming changes are introduced in a predictable manner. This makes sure that all Oryx users are informed and adequately prepared for the release of new features and removal of outdated ones.
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/oryx.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/oryx.md
@@ -5,12 +5,6 @@ template: concept-topic-template
 last_updated: Apr 4, 2023
 ---
 
-{% info_block warningBox %}
-
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
-
 Oryx is a framework that empowers developers to build composable frontends with ease. It provides a rich library of components, including a design system, which lets developers create modern and visually appealing user interfaces. The components integrate with Spryker APIs by default, providing a seamless experience for developers.
 
 There are different ways to learn Oryx. To start developing with Oryx right away, see the [setup guide](/docs/scos/dev/front-end-development/{{page.version}}/oryx/set-up-oryx.html). If you want to first learn more about Oryx, continue reading this document.

--- a/docs/scos/dev/front-end-development/202307.0/oryx/reactivity/key-concepts-of-reactivity.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/reactivity/key-concepts-of-reactivity.md
@@ -5,11 +5,7 @@ template: concept-topic-template
 last_updated: Apr 3, 2023
 ---
 
-{% info_block warningBox %}
 
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 ## Reactive data streams
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/reactivity/oryx-integration-of-backend-apis.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/reactivity/oryx-integration-of-backend-apis.md
@@ -5,11 +5,6 @@ template: concept-topic-template
 last_updated: Apr 3, 2023
 ---
 
-{% info_block warningBox %}
-
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 To compose a frontend application from different backend APIs, Oryx provides a flexible architecture. This architecture lets you adapt third-party APIs without changing business logic and components. For example, when an alternative search system is used, the existing application layers and components can remain unchanged.
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/reactivity/reactive-components.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/reactivity/reactive-components.md
@@ -5,11 +5,7 @@ template: concept-topic-template
 last_updated: Apr 3, 2023
 ---
 
-{% info_block warningBox %}
 
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 Components are organized by domains-for example, components in a product domain. They can leverage domain logic to communicate with the associated backend API. Each domain is shipped with a domain service that provides an API to communicate with a backend API. For example, when rendering product data, `ProductService` can be used as follows:
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/reactivity/reactivity.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/reactivity/reactivity.md
@@ -5,11 +5,6 @@ template: concept-topic-template
 last_updated: Apr 3, 2023
 ---
 
-{% info_block warningBox %}
-
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 Reactivity is a fundamental concept in modern web development that enables dynamic, real-time updates to the user interface. In interactive applications, and single-page application (SPA) in particular, reactivity ensures that the displayed data is constantly in sync with the underlying data model, even as that data is loaded asynchronously and in real time from a backend API.
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/set-up-oryx.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/set-up-oryx.md
@@ -5,12 +5,6 @@ last_updated: Apr 3, 2023
 template: howto-guide-template
 ---
 
-{% info_block warningBox %}
-
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
-
 This document describes how to set up an environment for developing in the Oryx framework. We provide a [boilerplate project](https://github.com/spryker/composable-frontend) that helps you quickstart the development. It contains minimum dependencies and configuration to install a standard Oryx application.
 
 ## Prerequisites

--- a/docs/scos/dev/front-end-development/202307.0/oryx/styling/oryx-color-system.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/styling/oryx-color-system.md
@@ -5,11 +5,7 @@ last_updated: July 9, 2023
 template: concept-topic-template
 ---
 
-{% info_block warningBox %}
 
-Oryx is currently running under an *Early Access Release*. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 
 An important part of the application user interface is the colors. Colors are used everywhere throughout components and are important for a good user experience. To ensure that you can adjust the colors to your needs throughout the application, a configurable color system is provided.

--- a/docs/scos/dev/front-end-development/202307.0/oryx/styling/oryx-design-tokens.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/styling/oryx-design-tokens.md
@@ -5,11 +5,7 @@ last_updated: July 24, 2023
 template: concept-topic-template
 ---
 
-{% info_block warningBox %}
 
-Oryx is currently running under an Early Access Release. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 Design tokens provide a powerful system for achieving consistent and customizable styles throughout an Oryx application. They are extensively used inside the [color system](/docs/scos/dev/front-end-development/{{page.version}}/oryx/styling/oryx-color-system.html), typography, icons, and many more. Ensuring a clean separation between styles and components, design tokens make it easier to manage and maintain the application's design system. This document focuses on the structure and usage of design tokens in Oryx.
 

--- a/docs/scos/dev/front-end-development/202307.0/oryx/styling/oryx-typography.md
+++ b/docs/scos/dev/front-end-development/202307.0/oryx/styling/oryx-typography.md
@@ -6,11 +6,6 @@ template: concept-topic-template
 ---
 
 
-{% info_block warningBox %}
-
-Oryx is currently running under an Early Access Release. Early Access Releases are subject to specific legal terms, they are unsupported and do not provide production-ready SLAs. They can also be deprecated without a General Availability Release. Nevertheless, we welcome feedback from early adopters on these cutting-edge, exploratory features.
-
-{% endinfo_block %}
 
 Typography is an important part of the look and feel of a web page. It contributes to the readability of text but also defines how page structure is perceived. Big headers typically go first and are perceived as more important, whereas smaller text seems less important.
 


### PR DESCRIPTION
Before 1.0 we've improved the package layers slightly to prevent cycle dependencies in the layered package architecture. 