### PR TITLE
Fix wrong path for adding/overriding Zed translations

### DIFF
--- a/docs/pbc/all/back-office/202307.0/back-office-translations-overview.md
+++ b/docs/pbc/all/back-office/202307.0/back-office-translations-overview.md
@@ -14,7 +14,7 @@ The *Back Office Translations* feature introduces a way to translate the Adminis
 
 There are two ways to assign a language to a user account: from the **Create new User** page of the **User Control&nbsp;<span aria-label="and then">></span> User** section or from the **Edit User** page of **User Control&nbsp;<span aria-label="and then">></span> User section** if the user is already created. Once the account language is changed, the respective user sees that their interface is translated into the corresponding language upon their next login.
 
-Translations are added by means of uploading CSV extension files to the folders of the target modules-`data/translation/Zed/{ModuleName}/{locale_code}.csv`
+Translations are added by means of uploading CSV extension files to the folders of the target modules `src/Pyz/Zed/Translator/data/{ModuleName}/{locale_code}.csv`
 
 The following are file name examples:
 


### PR DESCRIPTION
## PR Description

According to our public demoshops it looks like the path for Zed translations is wrong in the documentation. See https://github.com/spryker-shop/b2b-demo-marketplace/blob/master/data/translation/README.md

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
