### PR TITLE
Typo: Fix Folder Names (b2b instead of b2c)

### DIFF
--- a/docs/scos/dev/set-up-spryker-locally/install-spryker/install/install-in-demo-mode-on-macos-and-linux.md
+++ b/docs/scos/dev/set-up-spryker-locally/install-spryker/install/install-in-demo-mode-on-macos-and-linux.md
@@ -54,7 +54,7 @@ This document describes how to install Spryker in [Demo Mode](/docs/scos/dev/set
 
     ```shell
     git clone https://github.com/spryker-shop/b2b-demo-shop.git -b 202307.0 --single-branch ./b2b-demo-shop && \
-    cd b2c-demo-shop
+    cd b2b-demo-shop
     ```
 
     * B2C Marketplace Demo Shop

--- a/docs/scos/dev/set-up-spryker-locally/install-spryker/install/install-in-demo-mode-on-windows.md
+++ b/docs/scos/dev/set-up-spryker-locally/install-spryker/install/install-in-demo-mode-on-windows.md
@@ -46,7 +46,7 @@ Depending on the needed WSL version, follow one of the guides:
 
     ```shell
     git clone https://github.com/spryker-shop/b2b-demo-shop.git -b 202307.0 --single-branch ./b2b-demo-shop && \
-    cd b2c-demo-shop
+    cd b2b-demo-shop
     ```
 
     * B2C Marketplace Demo Shop

--- a/docs/scos/dev/set-up-spryker-locally/install-spryker/install/install-in-development-mode-on-windows.md
+++ b/docs/scos/dev/set-up-spryker-locally/install-spryker/install/install-in-development-mode-on-windows.md
@@ -58,7 +58,7 @@ Recommended: `/home/jdoe/workspace/project`.
 
     ```shell
     git clone https://github.com/spryker-shop/b2b-demo-shop.git -b 202307.0 --single-branch ./b2b-demo-shop && \
-    cd b2c-demo-shop
+    cd b2b-demo-shop
     ```
 
     * B2C Marketplace Demo Shop


### PR DESCRIPTION
## PR Description
Typo fix: it's needed to cd into folder b2b-demo-shop

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
