### PR TITLE
Improve NewRelic Integration

### DIFF
--- a/docs/scos/dev/the-docker-sdk/202204.0/configure-services.md
+++ b/docs/scos/dev/the-docker-sdk/202204.0/configure-services.md
@@ -597,7 +597,7 @@ class NewRelicMonitoringExtensionPlugin extends SprykerNewRelicMonitoringExtensi
         }
 ​
         // Custom application environment name, or use $environment as fallback
-        $environment = getenv('NEWRELIC_CUSTOM_APP_ENVIRONMENT') ?? $environment;
+        $environment = getenv('NEWRELIC_CUSTOM_APP_ENVIRONMENT') ?: $environment;
 ​
         $this->application = $application . '-' . $store . ' (' . $environment . ')';
 ​

--- a/docs/scos/dev/the-docker-sdk/202204.0/configure-services.md
+++ b/docs/scos/dev/the-docker-sdk/202204.0/configure-services.md
@@ -476,12 +476,15 @@ composer require spryker-eco/new-relic
 
 ```yaml
 image:
-    tag: spryker/php:7.4 # the image tag that has been previously used in `image`
+    ...
     php:
         ...
         enabled-extensions:
             ...
             - newrelic
+    environment:
+        ...
+        NEWRELIC_CUSTOM_APP_ENVIRONMENT: ENVIRONMENT_VALUE_HERE # staging, dev, production, uat
 ```
 
 2. Push and deploy the changes using one of the following guides:
@@ -523,7 +526,7 @@ docker:
 
 ```yaml
 image:
-    tag: spryker/php:7.4 # the image tag that has been previously used in `image`
+    ...
     php:
         ...
         enabled-extensions:
@@ -535,21 +538,21 @@ image:
 
 By default, in the New Relic dashboard, the APM is displayed as `company-staging-newrelic-app`. To improve visibility, you may want to configure each application as a separate APM. For example, `YVES-DE (docker.dev)`.
 
-To do it, adjust the Monitoring service in `src/Pyz/Service/Monitoring/MonitoringDependencyProvider.php`:  
+To do it, add the `NewRelicMonitoringExtensionPlugin` by creating the class `src/Pyz/Service/Monitoring/MonitoringDependencyProvider.php`:  
 
 ```php
 <?php declare(strict_types = 1);
-
+​
 /**
  * This file is part of the Spryker Commerce OS.
  * For full license information, please view the LICENSE file that was distributed with this source code.
  */
-
+​
 namespace Pyz\Service\Monitoring;
-
+​
 use Spryker\Service\Monitoring\MonitoringDependencyProvider as SprykerMonitoringDependencyProvider;
-use SprykerEco\Service\NewRelic\Plugin\NewRelicMonitoringExtensionPlugin;
-
+use Pyz\Service\NewRelic\Plugin\NewRelicMonitoringExtensionPlugin;
+​
 class MonitoringDependencyProvider extends SprykerMonitoringDependencyProvider
 {
     /**
@@ -560,6 +563,45 @@ class MonitoringDependencyProvider extends SprykerMonitoringDependencyProvider
         return [
             new NewRelicMonitoringExtensionPlugin(),
         ];
+    }
+}
+```
+
+Next create the class `src/Pyz/Service/NewRelic/Plugin/NewRelicMonitoringExtensionPlugin.php`
+
+```php
+<?php
+​
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+​
+namespace Pyz\Service\NewRelic\Plugin;
+​
+use SprykerEco\Service\NewRelic\Plugin\NewRelicMonitoringExtensionPlugin as SprykerNewRelicMonitoringExtensionPlugin;
+​
+class NewRelicMonitoringExtensionPlugin extends SprykerNewRelicMonitoringExtensionPlugin
+{
+    /**
+     * @param string|null $application
+     * @param string|null $store
+     * @param string|null $environment
+     *
+     * @return void
+     */
+    public function setApplicationName(?string $application = null, ?string $store = null, ?string $environment = null): void
+    {
+        if (!$this->isActive) {
+            return;
+        }
+​
+        // Custom application environment name, or use $environment as fallback
+        $environment = getenv('NEWRELIC_CUSTOM_APP_ENVIRONMENT') ?? $environment;
+​
+        $this->application = $application . '-' . $store . ' (' . $environment . ')';
+​
+        newrelic_set_appname($this->application, null, false);
     }
 }
 ```

--- a/docs/scos/dev/the-docker-sdk/202204.0/configure-services.md
+++ b/docs/scos/dev/the-docker-sdk/202204.0/configure-services.md
@@ -567,7 +567,7 @@ class MonitoringDependencyProvider extends SprykerMonitoringDependencyProvider
 }
 ```
 
-Next create the class `src/Pyz/Service/NewRelic/Plugin/NewRelicMonitoringExtensionPlugin.php`
+Next, create the class `src/Pyz/Service/NewRelic/Plugin/NewRelicMonitoringExtensionPlugin.php`
 
 ```php
 <?php

--- a/docs/scos/dev/the-docker-sdk/202311.0/configure-services.md
+++ b/docs/scos/dev/the-docker-sdk/202311.0/configure-services.md
@@ -480,12 +480,15 @@ composer require spryker-eco/new-relic
 
 ```yaml
 image:
-    tag: spryker/php:7.4 # the image tag that has been previously used in `image`
+    ...
     php:
         ...
         enabled-extensions:
             ...
             - newrelic
+    environment:
+        ...
+        NEWRELIC_CUSTOM_APP_ENVIRONMENT: ENVIRONMENT_VALUE_HERE # staging, dev, production, uat
 ```
 
 2. Push and deploy the changes using one of the following guides:
@@ -505,7 +508,7 @@ Once New Relic is enabled, in the New Relic dashboard, you may see either `compa
 
 {% info_block infoBox %}
 
-If you update the name of an application, [contact support]((/docs/scos/user/intro-to-spryker/support/how-to-use-the-support-portal.html) to update the changes in your APM.
+If you update the name of an application, [contact support](/docs/scos/user/intro-to-spryker/support/how-to-use-the-support-portal.html) to update the changes in your APM.
 
 {% endinfo_block %}
 
@@ -527,7 +530,7 @@ docker:
 
 ```yaml
 image:
-    tag: spryker/php:7.4 # the image tag that has been previously used in `image`
+    ...
     php:
         ...
         enabled-extensions:
@@ -539,21 +542,21 @@ image:
 
 By default, in the New Relic dashboard, the APM is displayed as `company-staging-newrelic-app`. To improve visibility, you may want to configure each application as a separate APM. For example, `YVES-DE (docker.dev)`.
 
-To do it, adjust the Monitoring service in `src/Pyz/Service/Monitoring/MonitoringDependencyProvider.php`:  
+To do it, add the `NewRelicMonitoringExtensionPlugin` by creating the class `src/Pyz/Service/Monitoring/MonitoringDependencyProvider.php`:  
 
 ```php
 <?php declare(strict_types = 1);
-
+​
 /**
  * This file is part of the Spryker Commerce OS.
  * For full license information, please view the LICENSE file that was distributed with this source code.
  */
-
+​
 namespace Pyz\Service\Monitoring;
-
+​
 use Spryker\Service\Monitoring\MonitoringDependencyProvider as SprykerMonitoringDependencyProvider;
-use SprykerEco\Service\NewRelic\Plugin\NewRelicMonitoringExtensionPlugin;
-
+use Pyz\Service\NewRelic\Plugin\NewRelicMonitoringExtensionPlugin;
+​
 class MonitoringDependencyProvider extends SprykerMonitoringDependencyProvider
 {
     /**
@@ -564,6 +567,45 @@ class MonitoringDependencyProvider extends SprykerMonitoringDependencyProvider
         return [
             new NewRelicMonitoringExtensionPlugin(),
         ];
+    }
+}
+```
+
+Next, create the class `src/Pyz/Service/NewRelic/Plugin/NewRelicMonitoringExtensionPlugin.php`
+
+```php
+<?php
+​
+/**
+ * MIT License
+ * For full license information, please view the LICENSE file that was distributed with this source code.
+ */
+​
+namespace Pyz\Service\NewRelic\Plugin;
+​
+use SprykerEco\Service\NewRelic\Plugin\NewRelicMonitoringExtensionPlugin as SprykerNewRelicMonitoringExtensionPlugin;
+​
+class NewRelicMonitoringExtensionPlugin extends SprykerNewRelicMonitoringExtensionPlugin
+{
+    /**
+     * @param string|null $application
+     * @param string|null $store
+     * @param string|null $environment
+     *
+     * @return void
+     */
+    public function setApplicationName(?string $application = null, ?string $store = null, ?string $environment = null): void
+    {
+        if (!$this->isActive) {
+            return;
+        }
+​
+        // Custom application environment name, or use $environment as fallback
+        $environment = getenv('NEWRELIC_CUSTOM_APP_ENVIRONMENT') ?: $environment;
+​
+        $this->application = $application . '-' . $store . ' (' . $environment . ')';
+​
+        newrelic_set_appname($this->application, null, false);
     }
 }
 ```


### PR DESCRIPTION
## PR Description

Within our online documentation, we explain how to enable our [Advanced NewRelic Integration](https://docs.spryker.com/docs/scos/dev/the-docker-sdk/202204.0/configure-services.html#new-relic) This integration depends on the spryker/eco module. 

The problem is, that the [SprykerEco NewRelic](https://github.com/spryker-eco/new-relic) module [relies on the environment property within the deploy file to set the environment within the NewRelic application](https://github.com/spryker-eco/new-relic/blob/master/src/SprykerEco/Service/NewRelic/Plugin/NewRelicMonitoringExtensionPlugin.php#L57).

Often times, our customers do not configure this value, and this means all of their environments might be named `docker`
This creates confusion and clashes within NewRelic

This PR changes the classes a little bit, and relies on a custom environment variable which makes it easier for the customer to control, and, removes the need for PAAS changes 

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
