### PR TITLE
Update cms_block.csv doc to reflect required template_name & template…

### DIFF
--- a/docs/pbc/all/content-management-system/202311.0/base-shop/import-and-export-data/import-file-details-cms-block.csv.md
+++ b/docs/pbc/all/content-management-system/202311.0/base-shop/import-and-export-data/import-file-details-cms-block.csv.md
@@ -29,8 +29,8 @@ data:import:cms-block
 | --- | --- | --- | --- | --- |
 | block_key | &check; | String |  |Block key identifier  |
 | block_name | &check; | String |Must be unique. Human-readable name. | Name of the block. |
-| template_name |  | String |  | Alphabetical identifier of the slot. It will be shown in the Back Office. |
-| template_path |  | String |Must be a valid path to a twig template. | Path to the Twig file template. |
+| template_name | &check; | String |  | Alphabetical identifier of the slot. It will be shown in the Back Office. |
+| template_path | &check; | String |Must be a valid path to a twig template. | Path to the Twig file template. |
 | active |  | Boolean |<ul><li>Inactive = 0</li><li>Active = 1</li><li>If empty during the import, the block will be imported as inactive.</li></ul> | Indicates if the block is active or inactive. |
 | placeholder.title.{ANY_LOCALE_NAME}*<br>Example value: *placeholder.title.en_US* |  | String |  | Placeholder for block title, translated into the specified locale (US for our example). |
 | placeholder.description.{ANY_LOCALE_NAME}*<br>Example value: *placeholder.description.en_US* |  | String |  | Placeholder for block description, translated into the specified locale (US for our example). |


### PR DESCRIPTION
https://docs.spryker.com/docs/pbc/all/content-management-system/202311.0/base-shop/import-and-export-data/import-file-details-cms-block.csv.html#import-file-parameters



## PR Description
Updates cms_block.csv doc to reflect actual state of spryker requiring template_name & template_path.
I was pointing a colleague to this doc, we tried to import cms_block.csv with only block_key,block_name,active fields, resulting in an exception.

At least template_name & template_path are mandatory as well.
![image](https://github.com/spryker/spryker-docs/assets/105295869/2c1ad3dc-0ffc-46ac-88bc-af0883a9c9ef)

## Checklist
- [X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
