### PR TITLE
Fix typo within installation instructions

### DIFF
--- a/docs/dg/dev/set-up-spryker-locally/install-spryker/install/install-in-demo-mode-on-macos-and-linux.md
+++ b/docs/dg/dev/set-up-spryker-locally/install-spryker/install/install-in-demo-mode-on-macos-and-linux.md
@@ -43,7 +43,7 @@ This document describes how to install Spryker in [Demo Mode](/docs/dg/dev/set-u
 
     ```shell
     git clone https://github.com/spryker-shop/b2b-demo-shop.git -b 202311.0 --single-branch ./b2b-demo-shop && \
-    cd b2c-demo-shop
+    cd b2b-demo-shop
     ```
 
     * B2C Marketplace Demo Shop

--- a/docs/dg/dev/set-up-spryker-locally/install-spryker/install/install-in-demo-mode-on-windows.md
+++ b/docs/dg/dev/set-up-spryker-locally/install-spryker/install/install-in-demo-mode-on-windows.md
@@ -41,7 +41,7 @@ Depending on the needed WSL version, follow one of the guides:
 
     ```shell
     git clone https://github.com/spryker-shop/b2b-demo-shop.git -b 202311.0 --single-branch ./b2b-demo-shop && \
-    cd b2c-demo-shop
+    cd b2b-demo-shop
     ```
 
     * B2C Marketplace Demo Shop

--- a/docs/dg/dev/set-up-spryker-locally/install-spryker/install/install-in-development-mode-on-windows.md
+++ b/docs/dg/dev/set-up-spryker-locally/install-spryker/install/install-in-development-mode-on-windows.md
@@ -53,7 +53,7 @@ Recommended: `/home/jdoe/workspace/project`.
 
     ```shell
     git clone https://github.com/spryker-shop/b2b-demo-shop.git -b 202311.0 --single-branch ./b2b-demo-shop && \
-    cd b2c-demo-shop
+    cd b2b-demo-shop
     ```
 
     * B2C Marketplace Demo Shop


### PR DESCRIPTION
## PR Description

There is a typo within the installation instructions, that instructs the user to clone the B2B code, and then to change into the directory `b2c-demo-shop`. This is incorrect
The directory that the user should change into is `b2b-demo-shop` where the code was cloned

![image](https://github.com/spryker/spryker-docs/assets/104058340/e58f6fb2-9d1d-4f9d-9dbd-57e078f422e9)


## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
