### PR TITLE
Fix newrelic_set_appname license parameter type

### DIFF
--- a/docs/dg/dev/integrate-and-configure/configure-services.md
+++ b/docs/dg/dev/integrate-and-configure/configure-services.md
@@ -619,7 +619,7 @@ class NewRelicMonitoringExtensionPlugin extends SprykerNewRelicMonitoringExtensi
 ​
         $this->application = $application . '-' . $store . ' (' . $environment . ')';
 ​
-        newrelic_set_appname($this->application, null, false);
+        newrelic_set_appname($this->application, '', false);
     }
 }
 ```


### PR DESCRIPTION
## PR Description
There is a bug within our instructions on how to [configure New Relic](https://docs.spryker.com/docs/dg/dev/integrate-and-configure/configure-services.html#new-relic) within the class `src/Pyz/Service/NewRelic/Plugin/NewRelicMonitoringExtensionPlugin.php` the license parameter is declared with the wrong type. Instead of `null` it should be an empty string `''`

This bug leads to a TypeError

This commit fixes the type to an empty string in line with the latest version of the [spryker-eco newrelic module](https://github.com/spryker-eco/new-relic/blob/master/src/SprykerEco/Service/NewRelic/Plugin/NewRelicMonitoringExtensionPlugin.php#L59C9-L59C61)

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
