### PR TITLE
Fix missing folder in the MessageStorageReader class path

### DIFF
--- a/docs/dg/dev/backend-development/data-manipulation/data-publishing/handle-data-with-publish-and-synchronization.md
+++ b/docs/dg/dev/backend-development/data-manipulation/data-publishing/handle-data-with-publish-and-synchronization.md
@@ -1225,7 +1225,7 @@ interface MessageStorageReaderInterface
     public function getMessageById(int $idMessage): HelloWorldStorageTransfer;
 }
 ```
-8. Add the `Pyz\Client\HelloWorldStorage\MessageStorageReader.php` class.
+8. Add the `Pyz\Client\HelloWorldStorage\Reader\MessageStorageReader.php` class.
 
 ```php
 <?php


### PR DESCRIPTION
## PR Description

Fix missing folder in the `MessageStorageReader` class path.

We can see by namespace `namespace Pyz\Client\HelloWorldStorage\Reader;` that it's supposed to be located under `Reader` directory

https://docs.spryker.com/docs/dg/dev/backend-development/data-manipulation/data-publishing/handle-data-with-publish-and-synchronization.html#client

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
