### PR TITLE
Missing composer package added

### DIFF
--- a/docs/dg/dev/upgrade-and-migrate/migrate-to-decoupled-glue-infrastructure/decoupled-glue-infrastructure-integrate-the-documentation-generator.md
+++ b/docs/dg/dev/upgrade-and-migrate/migrate-to-decoupled-glue-infrastructure/decoupled-glue-infrastructure-integrate-the-documentation-generator.md
@@ -29,7 +29,7 @@ To start the integration of the feature, overview and install the necessary feat
 Install the required modules using Composer:
 
 ```bash
-composer require spryker/documentation-generator-api:"^1.0.0" spryker/documentation-generator-open-api:"^1.0.0" --update-with-dependencies
+composer require spryker/documentation-generator-api:"^1.0.0" spryker/documentation-generator-open-api:"^1.0.0" composer require spryker/glue-storefront-api-application-glue-json-api-convention-connector:"1.0.0" --update-with-dependencies
 ```
 
 {% info_block warningBox "Verification" %}


### PR DESCRIPTION
## PR Description
There is a missing package in "Decoupled Glue infrastructure: Integrate the documentation generator" page. Due to this missing composer package, the documentation generation does not happen.

The code block for `DocumentationGeneratorApiDependencyProvider` requires the installation of `spryker/glue-storefront-api-application-glue-json-api-convention-connector` package.

This is a mandatory step to make sure you are aware of the license agreement and agree to it. `HASH_OF_COMMIT_YOU_ARE_BASING_YOUR_BRANCH_FROM_MASTER_BRANCH` is a hash of the commit you are basing your branch from the master branch. You can take it from commits list of master branch before you submit a PR.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
