### PR TITLE
Update install-docker-prerequisites-on-macos.md

### DIFF
--- a/docs/dg/dev/set-up-spryker-locally/install-spryker/install-docker-prerequisites/install-docker-prerequisites-on-macos.md
+++ b/docs/dg/dev/set-up-spryker-locally/install-spryker/install-docker-prerequisites/install-docker-prerequisites-on-macos.md
@@ -31,8 +31,8 @@ Review the system and software requirements in the table and configure them usin
 | Docker | 18.09.1 or higher |
 | Docker Compose | 2.0 or higher |  
 | vCPU | 4 or more |
-| RAM  | 4GB or more |
-| Swap  | 2GB or more |
+| RAM  | 32GB or more |
+| Swap  | 4GB or more |
 
 
 ## Install and configure a Docker manager


### PR DESCRIPTION
## PR Description
The recommended RAM-size of 4GB is not enough to work with Spryker on local setup.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
