### PR TITLE
Update install-docker-prerequisites-on-windows-with-wsl1.md

### DIFF
--- a/docs/dg/dev/set-up-spryker-locally/install-spryker/install-docker-prerequisites/install-docker-prerequisites-on-windows-with-wsl1.md
+++ b/docs/dg/dev/set-up-spryker-locally/install-spryker/install-docker-prerequisites/install-docker-prerequisites-on-windows-with-wsl1.md
@@ -29,8 +29,8 @@ This document describes the prerequisites for installing Spryker on Windows.
 | CPU SLAT-capable feature | Enabled   |  SLAT is CPU related feature. It is called Rapid Virtualization Indexing (RVI). |
 | Docker | 18.09.1 or higher |
 | Docker Compose | 2.0 or higher      |  
-| RAM  | 4GB or more       |
-| Swap  | 2GB or more       |
+| RAM  | 32GB or more       |
+| Swap  | 4GB or more       |
 
 ## Install and configure the required software
 


### PR DESCRIPTION
## PR Description
The recommended RAM-size of 4GB is not enough to work with Spryker on local setup.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
