### PR TITLE
Update install-prerequisites-and-enable-acp.md

### DIFF
--- a/docs/dg/dev/acp/install-prerequisites-and-enable-acp.md
+++ b/docs/dg/dev/acp/install-prerequisites-and-enable-acp.md
@@ -167,6 +167,8 @@ Make sure that no deprecated plugins are enabled. Ideally, the content of each o
 
 namespace Pyz\Zed\MessageBroker;
 
+use Spryker\Zed\KernelApp\Communication\Plugin\MessageBroker\ActiveAppFilterMessageChannelPlugin;
+use Spryker\Zed\KernelApp\Communication\Plugin\MessageBroker\AppConfigMessageHandlerPlugin;
 use Spryker\Zed\MessageBroker\Communication\Plugin\MessageBroker\CorrelationIdMessageAttributeProviderPlugin;
 use Spryker\Zed\MessageBroker\Communication\Plugin\MessageBroker\TenantActorMessageAttributeProviderPlugin;
 use Spryker\Zed\MessageBroker\Communication\Plugin\MessageBroker\TimestampMessageAttributeProviderPlugin;
@@ -179,6 +181,16 @@ use Spryker\Zed\Session\Communication\Plugin\MessageBroker\SessionTrackingIdMess
 
 class MessageBrokerDependencyProvider extends SprykerMessageBrokerDependencyProvider
 {
+    /**
+     * @return array<\Spryker\Zed\MessageBrokerExtension\Dependency\Plugin\MessageHandlerPluginInterface>
+     */
+    public function getMessageHandlerPlugins(): array
+    {
+        return [
+            new AppConfigMessageHandlerPlugin(),
+        ];
+    }
+
     /**
      * @return array<\Spryker\Zed\MessageBrokerExtension\Dependency\Plugin\MessageSenderPluginInterface>
      */


### PR DESCRIPTION
## PR labels
When the PR is ready for review, add a TW review needed label. This lets us keep track of PRs that need to be merged and merge them in time.

## PR Description

'app-events' messages were not processed by the message broker. After some debugging I found that there was an exception happening in vendor/symfony/messenger/Worker.php:161, that no handler for AppConfigUpdatedTransfer could be found.

After adding the plugin to \Pyz\Zed\MessageBroker\MessageBrokerDependencyProvider::getMessageHandlerPlugins(), the  'app-events' messages are processed.

Also 'use' for ActiveAppFilterMessageChannelPlugin was missing from the code snippet.

## Tickets
If changes are associated with a ticket, add a docs ticket here.

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
