### PR TITLE
CC-38074: Add Form Fill Agent documentation to Backoffice Assistant

### DIFF
--- a/docs/dg/dev/ai/ai-commerce/backoffice-assistant/backoffice-assistant.md
+++ b/docs/dg/dev/ai/ai-commerce/backoffice-assistant/backoffice-assistant.md
@@ -1,7 +1,7 @@
 ---
 title: Back Office Assistant
 description: Technical overview of the Back Office Assistant feature — architecture, agents, AiFoundation integration, and configuration options.
-last_updated: Apr 3, 2026
+last_updated: Mar 31, 2026
 template: concept-topic-template
 ---
 

--- a/docs/dg/dev/ai/ai-commerce/backoffice-assistant/backoffice-assistant.md
+++ b/docs/dg/dev/ai/ai-commerce/backoffice-assistant/backoffice-assistant.md
@@ -23,7 +23,7 @@ Back Office Assistant ships with four built-in agents:
 
 | AGENT | PLUGIN | DESCRIPTION |
 |-------|--------|-------------|
-| General Purpose | `GeneralPurposeAgentPlugin` | Answers general Spryker Back Office questions and provides navigation guidance. |
+| General Purpose | `GeneralAgentPlugin` | Answers general Spryker Back Office questions and provides navigation guidance. |
 | Order Management | `OrderManagementAgentPlugin` | Provides read-only access to order data and OMS state information for diagnosing order issues. |
 | Discount Management | `DiscountManagementAgentPlugin` | Creates and updates discounts through the Back Office API. |
 | Form Fill | `FormFillAgentPlugin` | Fills Back Office forms using natural language instructions. |

--- a/docs/dg/dev/ai/ai-commerce/backoffice-assistant/backoffice-assistant.md
+++ b/docs/dg/dev/ai/ai-commerce/backoffice-assistant/backoffice-assistant.md
@@ -1,7 +1,7 @@
 ---
 title: Back Office Assistant
 description: Technical overview of the Back Office Assistant feature — architecture, agents, AiFoundation integration, and configuration options.
-last_updated: Mar 31, 2026
+last_updated: Apr 3, 2026
 template: concept-topic-template
 ---
 
@@ -19,13 +19,14 @@ Streaming responses are delivered to the browser using Server-Sent Events (SSE),
 
 ## Agents
 
-Back Office Assistant ships with three built-in agents:
+Back Office Assistant ships with four built-in agents:
 
 | AGENT | PLUGIN | DESCRIPTION |
 |-------|--------|-------------|
 | General Purpose | `GeneralPurposeAgentPlugin` | Answers general Spryker Back Office questions and provides navigation guidance. |
 | Order Management | `OrderManagementAgentPlugin` | Provides read-only access to order data and OMS state information for diagnosing order issues. |
 | Discount Management | `DiscountManagementAgentPlugin` | Creates and updates discounts through the Back Office API. |
+| Form Fill | `FormFillAgentPlugin` | Fills Back Office forms using natural language instructions. |
 
 Agents are registered in `AiCommerceDependencyProvider::getBackofficeAssistantAgentPlugins()`.
 
@@ -39,6 +40,7 @@ Each agent uses a set of tools registered in `AiFoundationDependencyProvider::ge
 | `OrderManagementToolSetPlugin` | Provides tools for fetching order lists and OMS process information. |
 | `OrderDetailsToolSetPlugin` | Provides tools for fetching detailed order data by reference or ID. |
 | `DiscountManagementToolSetPlugin` | Provides tools for reading, creating, and updating discounts. |
+| `FormFillToolSetPlugin` | Provides tools for filling Back Office form fields with values derived from natural language instructions. |
 
 ## SSE streaming
 
@@ -61,6 +63,7 @@ The following configuration keys are used:
 | `AiCommerceConstants::AI_CONFIGURATION_GENERAL_PURPOSE` | Configuration for the General Purpose agent. |
 | `AiCommerceConstants::AI_CONFIGURATION_ORDER_MANAGEMENT` | Configuration for the Order Management agent. |
 | `AiCommerceConstants::AI_CONFIGURATION_DISCOUNT_MANAGEMENT` | Configuration for the Discount Management agent. |
+| `AiCommerceConstants::AI_CONFIGURATION_FORM_FILL` | Configuration for the Form Fill agent. |
 
 ## System prompts
 
@@ -75,6 +78,7 @@ The feature and individual agents can be enabled or disabled from the Back Offic
 | `is_enabled` | `false` | Enables or disables the Back Office Assistant chat widget. |
 | `is_order_management_agent_enabled` | `true` | Enables or disables the Order Management Agent. |
 | `is_discount_management_agent_enabled` | `true` | Enables or disables the Discount Management Agent. |
+| `is_form_fill_agent_enabled` | `true` | Enables or disables the Form Fill Agent. |
 
 ## Install
 

--- a/docs/dg/dev/ai/ai-commerce/backoffice-assistant/install-backoffice-assistant.md
+++ b/docs/dg/dev/ai/ai-commerce/backoffice-assistant/install-backoffice-assistant.md
@@ -1,7 +1,7 @@
 ---
 title: Install Back Office Assistant
 description: Learn how to install the Back Office Assistant feature that provides an AI-powered chat widget in the Spryker Back Office.
-last_updated: Apr 3, 2026
+last_updated: Apr 13, 2026
 template: feature-integration-guide-template
 ---
 
@@ -296,7 +296,9 @@ In `src/Pyz/Zed/Gui/Presentation/Layout/layout.twig`, include the chat widget pa
 {% extends '@Spryker:Gui/Layout/layout.twig' %}
 
 {% block footer_js %}
-    {% include '@AiCommerce/Partials/chat-widget.twig' %}
+    {% if isBackofficeAssistantConnected is defined and isBackofficeAssistantConnected %}
+        {% include '@AiCommerce/Partials/chat-widget.twig' %}
+    {% endif %}
     {{ parent() }}
 {% endblock %}
 {% endraw %}

--- a/docs/dg/dev/ai/ai-commerce/backoffice-assistant/install-backoffice-assistant.md
+++ b/docs/dg/dev/ai/ai-commerce/backoffice-assistant/install-backoffice-assistant.md
@@ -1,7 +1,7 @@
 ---
 title: Install Back Office Assistant
 description: Learn how to install the Back Office Assistant feature that provides an AI-powered chat widget in the Spryker Back Office.
-last_updated: Mar 31, 2026
+last_updated: Apr 3, 2026
 template: feature-integration-guide-template
 ---
 
@@ -73,6 +73,12 @@ $config[AiFoundationConstants::AI_CONFIGURATIONS] = [
             'model' => 'gpt-4.1', // fast non-reasoning model
         ]),
     ]),
+    AiCommerceConstants::AI_CONFIGURATION_FORM_FILL => array_merge($openAiConfiguration, [
+        'system_prompt' => AiFoundationConstants::CONFIGURATION_REFERENCE_PREFIX . AiCommerceConstants::CONFIGURATION_KEY_FORM_FILL_SYSTEM_PROMPT,
+        'provider_config' => array_merge($openAiConfiguration['provider_config'], [
+            'model' => 'gpt-4.1', // fast non-reasoning model
+        ]),
+    ]),
 ];
 ```
 
@@ -84,9 +90,10 @@ Register the following plugins to integrate the Back Office Assistant agents:
 
 | PLUGIN | SPECIFICATION | PREREQUISITES | NAMESPACE |
 |--------|---------------|---------------|-----------|
-| `GeneralPurposeAgentPlugin` | Registers the General Purpose agent that answers Back Office navigation and how-to questions. | | `SprykerFeature\Zed\AiCommerce\Communication\Plugin\Agent` |
+| `GeneralAgentPlugin` | Registers the General Purpose agent that answers Back Office navigation and how-to questions. | | `SprykerFeature\Zed\AiCommerce\Communication\Plugin\Agent` |
 | `OrderManagementAgentPlugin` | Registers the Order Management agent that provides read-only access to order and OMS data. | | `SprykerFeature\Zed\AiCommerce\Communication\Plugin\Agent` |
 | `DiscountManagementAgentPlugin` | Registers the Discount Management agent that can create and update discounts. | | `SprykerFeature\Zed\AiCommerce\Communication\Plugin\Agent` |
+| `FormFillAgentPlugin` | Registers the Form Fill agent that fills Back Office forms using natural language instructions. | | `SprykerFeature\Zed\AiCommerce\Communication\Plugin\Agent` |
 
 **src/Pyz/Zed/AiCommerce/AiCommerceDependencyProvider.php**
 
@@ -97,7 +104,8 @@ namespace Pyz\Zed\AiCommerce;
 
 use SprykerFeature\Zed\AiCommerce\AiCommerceDependencyProvider as SprykerFeatureAiCommerceDependencyProvider;
 use SprykerFeature\Zed\AiCommerce\Communication\Plugin\Agent\DiscountManagementAgentPlugin;
-use SprykerFeature\Zed\AiCommerce\Communication\Plugin\Agent\GeneralPurposeAgentPlugin;
+use SprykerFeature\Zed\AiCommerce\Communication\Plugin\Agent\FormFillAgentPlugin;
+use SprykerFeature\Zed\AiCommerce\Communication\Plugin\Agent\GeneralAgentPlugin;
 use SprykerFeature\Zed\AiCommerce\Communication\Plugin\Agent\OrderManagementAgentPlugin;
 
 class AiCommerceDependencyProvider extends SprykerFeatureAiCommerceDependencyProvider
@@ -108,9 +116,10 @@ class AiCommerceDependencyProvider extends SprykerFeatureAiCommerceDependencyPro
     protected function getBackofficeAssistantAgentPlugins(): array
     {
         return [
-            new GeneralPurposeAgentPlugin(),
+            new GeneralAgentPlugin(),
             new OrderManagementAgentPlugin(),
             new DiscountManagementAgentPlugin(),
+            new FormFillAgentPlugin(),
         ];
     }
 }
@@ -127,6 +136,7 @@ Register the following plugins in `AiFoundationDependencyProvider`:
 | `OrderManagementToolSetPlugin` | Registers tools for fetching order lists and OMS process information. | | `SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation` |
 | `OrderDetailsToolSetPlugin` | Registers tools for fetching detailed order data by reference or ID. | | `SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation` |
 | `DiscountManagementToolSetPlugin` | Registers tools for reading, creating, and updating discounts. | | `SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation` |
+| `FormFillToolSetPlugin` | Registers tools for filling Back Office form fields. | | `SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation` |
 
 **src/Pyz/Zed/AiFoundation/AiFoundationDependencyProvider.php**
 
@@ -142,6 +152,7 @@ use Spryker\Zed\AiFoundation\Communication\Plugin\Log\AiInteractionHandlerPlugin
 use SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation\BackofficeAssistantSsePostToolCallPlugin;
 use SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation\BackofficeAssistantSsePreToolCallPlugin;
 use SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation\DiscountManagementToolSetPlugin;
+use SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation\FormFillToolSetPlugin;
 use SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation\NavigationToolSetPlugin;
 use SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation\OrderDetailsToolSetPlugin;
 use SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation\OrderManagementToolSetPlugin;
@@ -199,6 +210,7 @@ class AiFoundationDependencyProvider extends SprykerAiFoundationDependencyProvid
             new OrderManagementToolSetPlugin(),
             new OrderDetailsToolSetPlugin(),
             new DiscountManagementToolSetPlugin(),
+            new FormFillToolSetPlugin(),
         ];
     }
 }

--- a/docs/pbc/all/ai-commerce/latest/backoffice-assistant.md
+++ b/docs/pbc/all/ai-commerce/latest/backoffice-assistant.md
@@ -1,7 +1,7 @@
 ---
 title: Back Office Assistant
 description: An AI-powered chat widget embedded in the Spryker Back Office that lets admin users manage orders, create discounts, and get navigation help through natural language.
-last_updated: Apr 3, 2026
+last_updated: Mar 31, 2026
 template: concept-topic-template
 ---
 

--- a/docs/pbc/all/ai-commerce/latest/backoffice-assistant.md
+++ b/docs/pbc/all/ai-commerce/latest/backoffice-assistant.md
@@ -1,7 +1,7 @@
 ---
 title: Back Office Assistant
 description: An AI-powered chat widget embedded in the Spryker Back Office that lets admin users manage orders, create discounts, and get navigation help through natural language.
-last_updated: Mar 31, 2026
+last_updated: Apr 3, 2026
 template: concept-topic-template
 ---
 
@@ -16,6 +16,7 @@ Back Office Assistant is an AI-powered chat widget embedded in the Spryker Back 
 | Navigation guidance | Answers questions about where to find features and provides clickable navigation links. |
 | Order management | Looks up orders by reference or ID, explains OMS states, and helps diagnose stuck orders. Read-only — does not modify orders. |
 | Discount management | Creates and updates discounts through a conversational interface. |
+| Form fill | Populates Back Office form fields using natural language instructions. |
 
 ## Use Back Office Assistant
 
@@ -32,6 +33,7 @@ Back Office Assistant is an AI-powered chat widget embedded in the Spryker Back 
 - *"Where do I configure tax rates?"*
 - *"What is the current state of order DE--1001?"*
 - *"Create a 10% discount for all orders over 50 EUR, valid for the next 30 days."*
+- *"Fill in the product form with name 'Premium Widget', SKU 'PW-001', and price 99.99."*
 
 ## Enable Back Office Assistant
 


### PR DESCRIPTION
## Summary

Documentation updates for the new Form Fill Agent feature (CC-38074).

- Added Form Fill Agent to the agents table (4 agents total)
- Fixed GeneralPurposeAgentPlugin → GeneralAgentPlugin rename
- Added FormFillToolSetPlugin to toolsets
- Added AI_CONFIGURATION_FORM_FILL configuration key
- Added is_form_fill_agent_enabled feature flag
- Updated PBC docs with form fill capability
- Added form fill usage example

## Changes

- **docs/dg/dev/ai/ai-commerce/backoffice-assistant/backoffice-assistant.md** — DG documentation update
- **docs/pbc/all/ai-commerce/latest/backoffice-assistant.md** — PBC documentation update

## Validation

✅ Vale (prose linting): 0 errors
✅ Markdownlint (Markdown syntax): 0 errors
✅ All internal links follow correct format