### PR TITLE
Formatting related links

### DIFF
--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.md
@@ -1,7 +1,7 @@
 ---
 title: AI Foundation Audit Logs
 description: Track and audit AI interactions with the AiFoundation module audit logging feature
-last_updated: Mar 11, 2026
+last_updated: Apr 22, 2026
 keywords: audit, logging, ai, foundation, tracking, compliance, ai interactions, monitoring
 template: howto-guide-template
 label: early-access

--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.md
@@ -7,13 +7,13 @@ template: howto-guide-template
 label: early-access
 related:
   - title: AiFoundation module Overview
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-module.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-module.html
   - title: Use AI tools with the AiFoundation module
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-tool-support.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-tool-support.html
   - title: Manage conversation history with the AiFoundation module
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-conversation-history.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-conversation-history.html
   - title: AI workflow orchestration with state machines
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-workflow-state-machine.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-workflow-state-machine.html
 ---
 
 This document describes how to use audit logging with the AiFoundation module to track and audit AI interactions in your Spryker application.

--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-conversation-history.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-conversation-history.md
@@ -6,15 +6,15 @@ keywords: foundation, ai, conversation history, conversation, context, database,
 template: howto-guide-template
 related:
   - title: AiFoundation module Overview
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-module.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-module.html
   - title: Use structured responses with the AiFoundation module
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-transfer-response.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-transfer-response.html
   - title: Use AI tools with the AiFoundation module
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-tool-support.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-tool-support.html
   - title: AI workflow orchestration with state machines
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-workflow-state-machine.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-workflow-state-machine.html
   - title: AI Interaction Audit Logs
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.html
 ---
 
 This document describes how to use conversation history with the AiFoundation module to maintain conversation context across multiple interactions, enabling multi-turn conversations where the AI can reference previous messages and provide contextually relevant responses.

--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-conversation-history.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-conversation-history.md
@@ -1,7 +1,7 @@
 ---
 title: Conversation History
 description: Persist and manage multi-turn conversations with conversation history using database storage
-last_updated: Mar 2, 2026
+last_updated: Apr 22, 2026
 keywords: foundation, ai, conversation history, conversation, context, database, multi-turn, dialogue, audit, logging, tracking
 template: howto-guide-template
 related:

--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-module.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-module.md
@@ -1,7 +1,7 @@
 ---
 title: AiFoundation module Overview
 description: Integrate AI foundation providers into the Spryker application
-last_updated: Mar 26, 2026
+last_updated: Apr 22, 2026
 keywords: foundation, ai, neuron, prompt, aiconfiguration, openai, anthropic, bedrock, aws, ollama, gemini, deepseek, huggingface, mistral, grok, azure-openai, agent, chat history, conversation, audit, logging, tracking
 template: howto-guide-template
 label: early-access

--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-module.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-module.md
@@ -7,15 +7,15 @@ template: howto-guide-template
 label: early-access
 related:
   - title: Use AI tools with the AiFoundation module
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-tool-support.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-tool-support.html
   - title: Use structured responses with the AiFoundation module
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-transfer-response.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-transfer-response.html
   - title: Manage conversation history with the AiFoundation module
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-conversation-history.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-conversation-history.html
   - title: AI workflow orchestration with state machines
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-workflow-state-machine.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-workflow-state-machine.html
   - title: AI Interaction Audit Logs
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.html
 ---
 
 This document describes how to integrate and use the AiFoundation module to interact with various AI providers in your Spryker application. The AiFoundation module provides a unified interface for working with multiple AI providers, such as OpenAI, Anthropic Claude, AWS Bedrock, and others.

--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-tool-support.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-tool-support.md
@@ -6,13 +6,13 @@ keywords: foundation, ai, tools, function calling, tool sets, plugins, openai, a
 template: howto-guide-template
 related:
   - title: AiFoundation module Overview
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-module.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-module.html
   - title: Use structured responses with the AiFoundation module
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-transfer-response.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-transfer-response.html
   - title: AI workflow orchestration with state machines
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-workflow-state-machine.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-workflow-state-machine.html
   - title: AI Interaction Audit Logs
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.html
 ---
 
 This document describes how to create and use AI tools with the AiFoundation module to extend AI capabilities by providing custom functions that AI models can invoke during conversations.

--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-tool-support.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-tool-support.md
@@ -1,7 +1,7 @@
 ---
 title: Use AI tools with the AiFoundation module
 description: Extend AI capabilities by providing custom tools that AI models can invoke during conversations
-last_updated: Mar 2, 2026
+last_updated: Apr 22, 2026
 keywords: foundation, ai, tools, function calling, tool sets, plugins, openai, anthropic, prompt, agent, audit, logging
 template: howto-guide-template
 related:

--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-transfer-response.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-transfer-response.md
@@ -6,15 +6,15 @@ keywords: foundation, ai, structured response, transfer, schema, json, openai, a
 template: howto-guide-template
 related:
   - title: AiFoundation module Overview
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-module.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-module.html
   - title: Use AI tools with the AiFoundation module
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-tool-support.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-tool-support.html
   - title: AI workflow orchestration with state machines
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-workflow-state-machine.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-workflow-state-machine.html
   - title: AI Interaction Audit Logs
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.html
   - title: Transfer objects
-    link: /docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/create-use-and-extend-the-transfer-objects.html
+    link: docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/create-use-and-extend-the-transfer-objects.html
 ---
 
 This document describes how to use structured responses with the AiFoundation module to receive validated, type-safe data from AI providers in the format of Spryker Transfer objects.

--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-transfer-response.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-transfer-response.md
@@ -1,7 +1,7 @@
 ---
 title: Use structured responses with the AiFoundation module
 description: Request and receive structured data from AI providers using Spryker Transfer objects
-last_updated: Mar 2, 2026
+last_updated: Apr 22, 2026
 keywords: foundation, ai, structured response, transfer, schema, json, openai, anthropic, prompt, validation, audit, logging
 template: howto-guide-template
 related:

--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-workflow-state-machine.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-workflow-state-machine.md
@@ -1,7 +1,7 @@
 ---
 title: AI workflow orchestration with state machines
 description: Learn how to orchestrate multi-step, multi-agent AI workflows using Spryker state machines
-last_updated: Mar 10, 2026
+last_updated: Apr 22, 2026
 keywords: ai, workflow, state-machine, orchestration, multi-agent, process, command, condition, structured-response
 template: howto-guide-template
 label: early-access

--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-workflow-state-machine.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-workflow-state-machine.md
@@ -7,15 +7,15 @@ template: howto-guide-template
 label: early-access
 related:
   - title: AiFoundation module overview
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-module.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-module.html
   - title: Use AI tools with the AiFoundation module
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-tool-support.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-tool-support.html
   - title: Use structured responses with the AiFoundation module
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-transfer-response.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-transfer-response.html
   - title: Manage conversation history with the AiFoundation module
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-conversation-history.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-conversation-history.html
   - title: AI Interaction Audit Logs
-    link: /docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.html
+    link: docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.html
 ---
 
 This guide shows you how to build multi-step, multi-agent AI workflows using Spryker state machines. By combining state machines with the AiFoundation module, you can orchestrate complex AI processes where agents execute tasks, make decisions based on results, and trigger subsequent steps.

--- a/docs/dg/dev/architecture/architecture-as-code.md
+++ b/docs/dg/dev/architecture/architecture-as-code.md
@@ -2,7 +2,7 @@
 title: Architecture as Code
 description: Learn how to implement Architecture as Code in your Spryker project using industry standards like arc42, C4 Model, and diagrams-as-code to maintain living, version-controlled documentation.
 keywords: Architecture as Code,arc42,C4 Model,diagrams-as-code,diagram
-last_updated: Feb 20, 2026
+last_updated: Apr 22, 2026
 template: concept-topic-template
 related:
   - title: Architectural Convention

--- a/docs/dg/dev/architecture/architecture-as-code.md
+++ b/docs/dg/dev/architecture/architecture-as-code.md
@@ -6,9 +6,9 @@ last_updated: Feb 20, 2026
 template: concept-topic-template
 related:
   - title: Architectural Convention
-    link: /docs/dg/dev/architecture/architectural-convention.html
+    link: docs/dg/dev/architecture/architectural-convention.html
   - title: Modules and Application Layers
-    link: /docs/dg/dev/architecture/modules-and-application-layers.html
+    link: docs/dg/dev/architecture/modules-and-application-layers.html
 ---
 
 Well-documented project architecture enables faster internal and external onboarding, passes audits cleanly and aligns teams on requirements. Without it, your system becomes a black box that only the original developers understand.

--- a/docs/dg/dev/architecture/architecture.md
+++ b/docs/dg/dev/architecture/architecture.md
@@ -1,7 +1,7 @@
 ---
 title: Architecture
 description: Explore Spryker's architectural principles, detailing the technical foundation for a scalable, modular ecommerce platform tailored to complex digital ecosystems.
-last_updated: Feb 20, 2026
+last_updated: Apr 22, 2026
 template: concept-topic-template
 originalLink: https://documentation.spryker.com/2021080/docs/about-the-architecture-guide
 originalArticleId: 926005b6-d8c9-4d6a-851a-f3a4f551d0d3

--- a/docs/dg/dev/architecture/architecture.md
+++ b/docs/dg/dev/architecture/architecture.md
@@ -9,7 +9,7 @@ redirect_from:
   - /docs/scos/dev/architecture/architecture.html
 related:
   - title: Architecture as Code
-    link: /docs/dg/dev/architecture/architecture-as-code.html
+    link: docs/dg/dev/architecture/architecture-as-code.html
   - title: Conceptual overview
     link: docs/dg/dev/architecture/conceptual-overview.html
   - title: Programming concepts

--- a/docs/dg/dev/guidelines/performance-guidelines/elastic-computing/new-relic-transaction-grouping-by-queue-names.md
+++ b/docs/dg/dev/guidelines/performance-guidelines/elastic-computing/new-relic-transaction-grouping-by-queue-names.md
@@ -3,8 +3,6 @@ title: New Relic transactions grouping by queue names
 description: Learn about Enhanced New Relic queue flow groups transactions by queue names for your Spryker based projects.
 last_updated: May 16, 2022
 template: concept-topic-template
-redirect_from:
-  - /docs/scos/dev/guidelines/performance-guidelines/elastic-computing/scalable-application-infrastructure-for-publish-and-sync-workers.html
 related:
   - title: RAM-aware batch processing
     link: docs/dg/dev/guidelines/performance-guidelines/elastic-computing/ram-aware-batch-processing.html

--- a/docs/dg/dev/guidelines/performance-guidelines/elastic-computing/new-relic-transaction-grouping-by-queue-names.md
+++ b/docs/dg/dev/guidelines/performance-guidelines/elastic-computing/new-relic-transaction-grouping-by-queue-names.md
@@ -1,7 +1,7 @@
 ---
 title: New Relic transactions grouping by queue names
 description: Learn about Enhanced New Relic queue flow groups transactions by queue names for your Spryker based projects.
-last_updated: May 16, 2022
+last_updated: Apr 22, 2026
 template: concept-topic-template
 related:
   - title: RAM-aware batch processing

--- a/docs/dg/dev/guidelines/testing-guidelines/cypress-testing.md
+++ b/docs/dg/dev/guidelines/testing-guidelines/cypress-testing.md
@@ -1,7 +1,7 @@
 ---
 title: E2E Testing with Cypress
 description: Learn how to use Cypress for end-to-end testing in Spryker projects.
-last_updated: March 02, 2026
+last_updated: Apr 22, 2026
 template: concept-topic-template
 related:
   - title: Running tests with Robot Framework

--- a/docs/dg/dev/guidelines/testing-guidelines/cypress-testing.md
+++ b/docs/dg/dev/guidelines/testing-guidelines/cypress-testing.md
@@ -5,11 +5,11 @@ last_updated: March 02, 2026
 template: concept-topic-template
 related:
   - title: Running tests with Robot Framework
-    link: /docs/dg/dev/guidelines/testing-guidelines/running-tests-with-robot-framework.html
+    link: docs/dg/dev/guidelines/testing-guidelines/running-tests-with-robot-framework.html
   - title: Setting up tests
-    link: /docs/dg/dev/guidelines/testing-guidelines/setting-up-tests.html
+    link: docs/dg/dev/guidelines/testing-guidelines/setting-up-tests.html
   - title: Testing best practices
-    link: /docs/dg/dev/guidelines/testing-guidelines/testing-best-practices/best-practices-for-effective-testing.html
+    link: docs/dg/dev/guidelines/testing-guidelines/testing-best-practices/best-practices-for-effective-testing.html
 ---
 
 Cypress is an end-to-end testing framework that provides a modern approach to testing web applications. Spryker provides a Cypress boilerplate project with pre-configured setup, best practices, and examples for testing Spryker-based applications.

--- a/docs/dg/dev/guidelines/testing-guidelines/executing-tests/test-console-commands.md
+++ b/docs/dg/dev/guidelines/testing-guidelines/executing-tests/test-console-commands.md
@@ -3,7 +3,6 @@ title: Test console commands
 description: Learn how to test console commands with test helpers using ConsoleHelper in your Spryker based projects.
 last_updated: Jan 12, 2022
 template: concept-topic-template
-redirect_from:
 related:
   - title: Available test helpers
     link: docs/dg/dev/guidelines/testing-guidelines/test-helpers/test-helpers.html

--- a/docs/dg/dev/guidelines/testing-guidelines/executing-tests/test-console-commands.md
+++ b/docs/dg/dev/guidelines/testing-guidelines/executing-tests/test-console-commands.md
@@ -1,7 +1,7 @@
 ---
 title: Test console commands
 description: Learn how to test console commands with test helpers using ConsoleHelper in your Spryker based projects.
-last_updated: Jan 12, 2022
+last_updated: Apr 22, 2026
 template: concept-topic-template
 related:
   - title: Available test helpers

--- a/docs/dg/dev/integrate-and-configure/integrate-confguration-feature.md
+++ b/docs/dg/dev/integrate-and-configure/integrate-confguration-feature.md
@@ -6,7 +6,7 @@ template: howto-guide-template
 
 related:
   - title: Configuration Management feature
-    link: /docs/dg/dev/backend-development/configuration-management.html
+    link: docs/dg/dev/backend-development/configuration-management.html
 ---
 
 This document describes how to install the Configuration Management feature.

--- a/docs/dg/dev/integrate-and-configure/integrate-confguration-feature.md
+++ b/docs/dg/dev/integrate-and-configure/integrate-confguration-feature.md
@@ -1,7 +1,7 @@
 ---
 title: Install the Configuration Management feature
 description: Learn how to integrate and configure Configuration Management feature in a Spryker project.
-last_updated: March 05, 2026
+last_updated: Apr 22, 2026
 template: howto-guide-template
 
 related:


### PR DESCRIPTION
This fixes the articles that have related links starting with slash leading to FE shwong them as [https://docs/dg/dev/ai/ai-foundation/ai-foundation-module.html](https://docs/dg/dev/ai/ai-foundation/ai-foundation-module.html). 


Example of a broken page is here [https://docs.spryker.com/docs/dg/dev/ai/ai-foundation/ai-foundation-transfer-response](https://docs.spryker.com/docs/dg/dev/ai/ai-foundation/ai-foundation-transfer-response): scroll to the bottom and click on the related links.