### PR TITLE
CC-38779: Document default_value_env_var for configuration secrets

### DIFF
--- a/docs/dg/dev/ai/ai-commerce/configure-multiple-ai-providers.md
+++ b/docs/dg/dev/ai/ai-commerce/configure-multiple-ai-providers.md
@@ -256,31 +256,7 @@ The AI vendor credentials (API tokens, AWS region) are managed through the Back 
 console configuration:sync
 ```
 
-## 3) Set credentials using environment variables (recommended)
-
-The AI vendor configuration schema uses `default_value_env_var` for secret settings such as API tokens. When the corresponding environment variable is set in the process environment, it is used as the runtime default — without storing the value in the database.
-
-The following environment variables are supported out of the box:
-
-| ENVIRONMENT VARIABLE | CREDENTIAL |
-|----------------------|------------|
-| `OPEN_AI_API_TOKEN` | OpenAI API token |
-
-Set the variable in your deployment environment or `.env` file:
-
-```bash
-OPEN_AI_API_TOKEN=sk-...
-```
-
-When the variable is set, you do not need to enter the credential manually in the Back Office. If a value is saved via the Back Office, it takes precedence over the environment variable.
-
-{% info_block infoBox "Other providers" %}
-
-AWS Bedrock and Anthropic credentials are configured in the Back Office only. Environment variable defaults are not available for those providers in the default schema.
-
-{% endinfo_block %}
-
-## 4) Optional: Set credentials in the Back Office
+## 3) Set credentials in the Back Office
 
 1. In the Back Office, go to **AI Vendor**.
 2. For each provider you want to use, open its tab (OpenAI, Anthropic, or AWS Bedrock) and enter the credentials:
@@ -293,7 +269,13 @@ AWS Bedrock and Anthropic credentials are configured in the Back Office only. En
 
 3. Click **Save**.
 
-## 5) Select the active provider per feature
+{% info_block infoBox "Environment variable alternative" %}
+
+You can also supply the OpenAI API token via the `OPEN_AI_API_TOKEN` environment variable. When set, it is used as the runtime default without storing the value in the database. For details, see [Configuration Management: Environment Variable Defaults](/docs/dg/dev/backend-development/configuration-management.html#environment-variable-defaults).
+
+{% endinfo_block %}
+
+## 4) Select the active provider per feature
 
 Each AI Commerce feature has an **AI Configuration** radio selector in the Back Office that controls which provider it uses.
 

--- a/docs/dg/dev/ai/ai-commerce/configure-multiple-ai-providers.md
+++ b/docs/dg/dev/ai/ai-commerce/configure-multiple-ai-providers.md
@@ -1,7 +1,7 @@
 ---
 title: Configure multiple AI providers for AI Commerce
 description: Learn how to configure OpenAI, AWS Bedrock, and Anthropic providers independently for each AI Commerce feature.
-last_updated: May 11, 2026
+last_updated: May 13, 2026
 template: howto-guide-template
 ---
 
@@ -256,7 +256,31 @@ The AI vendor credentials (API tokens, AWS region) are managed through the Back 
 console configuration:sync
 ```
 
-## 3) Set credentials in the Back Office
+## 3) Set credentials using environment variables (recommended)
+
+The AI vendor configuration schema uses `default_value_env_var` for secret settings such as API tokens. When the corresponding environment variable is set in the process environment, it is used as the runtime default — without storing the value in the database.
+
+The following environment variables are supported out of the box:
+
+| ENVIRONMENT VARIABLE | CREDENTIAL |
+|----------------------|------------|
+| `OPEN_AI_API_TOKEN` | OpenAI API token |
+
+Set the variable in your deployment environment or `.env` file:
+
+```bash
+OPEN_AI_API_TOKEN=sk-...
+```
+
+When the variable is set, you do not need to enter the credential manually in the Back Office. If a value is saved via the Back Office, it takes precedence over the environment variable.
+
+{% info_block infoBox "Other providers" %}
+
+AWS Bedrock and Anthropic credentials are configured in the Back Office only. Environment variable defaults are not available for those providers in the default schema.
+
+{% endinfo_block %}
+
+## 4) Optional: Set credentials in the Back Office
 
 1. In the Back Office, go to **AI Vendor**.
 2. For each provider you want to use, open its tab (OpenAI, Anthropic, or AWS Bedrock) and enter the credentials:
@@ -269,7 +293,7 @@ console configuration:sync
 
 3. Click **Save**.
 
-## 4) Select the active provider per feature
+## 5) Select the active provider per feature
 
 Each AI Commerce feature has an **AI Configuration** radio selector in the Back Office that controls which provider it uses.
 

--- a/docs/dg/dev/backend-development/configuration-management.md
+++ b/docs/dg/dev/backend-development/configuration-management.md
@@ -1,7 +1,7 @@
 ---
 title: Configuration Management feature
 description: Learn how to use the Configuration Management feature in a Spryker project.
-last_updated: Apr 27, 2026
+last_updated: May 13, 2026
 template: concept-topic-template
 related:
   - title: Install the Configuration Management feature
@@ -295,6 +295,7 @@ settings:
     template: '@MyModule/Configuration/custom-input.twig'  # Optional. Custom Twig template.
     type: string                         # Required. Data type.
     default_value: My Store              # Optional. Fallback value.
+    default_value_env_var: MY_ENV_VAR    # Optional. Env var override for default value.
     options:                             # Optional. For select/multiselect/radio types.
       - value: option_a
         label: Option A
@@ -321,6 +322,7 @@ settings:
 | `template`      | string    | No       | `null`       | max 255 chars        | Custom Twig template. Overrides type-based widget.   |
 | `type`          | string    | Yes      | --           | See types table      | Value data type. Determines backoffice input widget. |
 | `default_value` | mixed     | No       | `null`       | Must match `type`    | Fallback when no value is saved at any scope.        |
+| `default_value_env_var` | string | No | `null` | `^[A-Z][A-Z0-9_]*$` | Name of an environment variable. When set and the variable is defined in the process environment, its value is used as the effective default at runtime, taking precedence over `default_value`. Intended primarily for secrets — the resolved value is never persisted to the database. |
 | `options`       | option[]  | No       | `[]`         | For select/multi/radio | Available choices. See [Options](#options).        |
 | `scopes`        | string[]  | No       | `['global']` | min 1 item           | Scopes where this setting can be configured. Constrained to parent group scopes. |
 | `order`         | integer   | No       | `0`          | --                   | Sort order for rendering. Lower values first.        |
@@ -430,6 +432,29 @@ options:
 | `value`       | string | Yes      | min 1 char    | Internal value stored when selected.     |
 | `label`       | string | Yes      | 1-255 chars   | Display label shown in backoffice.       |
 | `description` | string | No       | max 500 chars | Additional explanation (for radio buttons). |
+
+#### Environment Variable Defaults
+
+Use `default_value_env_var` to source the effective default for a setting from a process environment variable at runtime. This is intended primarily for secrets such as API tokens, where you want the default resolved from a CI or deployment environment variable rather than hardcoded in the YAML file or stored in the database.
+
+```yaml
+settings:
+  - key: api_token
+    name: API Token
+    type: string
+    default_value: ''
+    default_value_env_var: OPEN_AI_API_TOKEN
+    secret: true
+    storefront: false
+```
+
+Behavior:
+
+- When the named environment variable is set in the process environment, its value is used as the runtime default instead of `default_value`.
+- When the variable is not set, `default_value` is used as normal.
+- `default_value_env_var` takes precedence over `default_value` but has lower precedence than a value explicitly saved in the database via the Back Office.
+- The resolved env var value is **never persisted** to the database.
+- The env var name must match the pattern `^[A-Z][A-Z0-9_]*$` (uppercase letters, digits, underscores; must start with a letter).
 
 #### Secret vs Storefront Behavior
 


### PR DESCRIPTION
## Summary

- Adds `default_value_env_var` to the YAML schema reference table and YAML example in the Configuration Management feature doc
- Adds a dedicated **Environment Variable Defaults** section explaining precedence, behavior, and format constraints
- Updates the AI Commerce multi-provider guide with a new step for setting OpenAI credentials via `OPEN_AI_API_TOKEN` env var (using the `default_value_env_var` mechanism)

## Related

- Suite PR: https://github.com/spryker/suite/pull/603
- Ticket: https://spryker.atlassian.net/browse/CC-38779

## Test plan

- [ ] Vale and markdownlint pass with 0 errors
- [ ] Internal links use `/docs/...html` format
- [ ] `last_updated` updated to 2026-05-13 in both files