### PR TITLE
Correct Docker SDK clone command path

### DIFF
--- a/docs/dg/dev/sdks/the-docker-sdk/choosing-a-docker-sdk-version.md
+++ b/docs/dg/dev/sdks/the-docker-sdk/choosing-a-docker-sdk-version.md
@@ -1,7 +1,7 @@
 ---
 title: Choosing a Docker SDK version
 description: Learn how to choose a versioning approach and configure a particular version of Docker SDK for your project.
-last_updated: Jul 11, 2023
+last_updated: May 15, 2026
 template: howto-guide-template
 originalLink: https://documentation.spryker.com/2021080/docs/choosing-a-docker-sdk-version
 originalArticleId: 18a333a7-2d89-455f-885a-92d24594fb31

--- a/docs/dg/dev/sdks/the-docker-sdk/choosing-a-docker-sdk-version.md
+++ b/docs/dg/dev/sdks/the-docker-sdk/choosing-a-docker-sdk-version.md
@@ -189,7 +189,7 @@ Do the following to fetch the chosen version of the Docker SDK:
  An example of a pipeline to fetch the chosen version of the Docker SDK:
 
 ```bash
-git clone git@github.com:spryker/docker-sdk.git .docker
+git clone git@github.com:spryker/docker-sdk.git ./docker
 cd docker
 git checkout "$(cat ../.git.docker | tr -d '\n\r')"
 cd ..


### PR DESCRIPTION
Fix the directory path in the git clone command for Docker SDK.

## PR Description
Describe the context for your changes and the changes you've made.

## Tickets
If changes are associated with a ticket, add a docs ticket here.


## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
- [x] I validated and improved the content with [Custom GPT](https://chatgpt.com/g/g-691b3026738081918f2785ae6267faab-spryker-doc-genius)
- [x] I checked my pages at the deployment preview website.
- [x] I invited a person to review and merge this PR.
