### PR TITLE
Moved the `Information disclosure via phpinfo() method` section from 202603 security page to 202604 spryker release.

### DIFF
--- a/docs/about/all/releases/release-notes-202604.0.md
+++ b/docs/about/all/releases/release-notes-202604.0.md
@@ -1,7 +1,7 @@
 ---
 title: Release notes 202604.0
 description: Release notes for Spryker Cloud Commerce OS version 202602.0
-last_updated: Apr 29, 2026
+last_updated: May 18, 2026
 template: concept-topic-template
 ---
 
@@ -471,6 +471,32 @@ We made your Spryker Commerce OS faster, more secure, and more stable.
 - [Split Publish & Synchronize queues for performance](/docs/dg/dev/guidelines/performance-guidelines/split-queues-performance.html)
 - [Merchant Portal and Back Office performance with ACL rules](/docs/dg/dev/guidelines/performance-guidelines/keeping-dependencies-updated.html#merchant-portal-and-back-office-performance-with-acl-rules)
 - [Order details page performance guidance](/docs/pbc/all/order-management-system/latest/base-shop/order-management-feature-overview/order-details-page-performance-overview.html)
+
+## Information disclosure via phpinfo() method
+
+Instances of phpinfo() were identified in the codebase, which could potentially expose sensitive configuration details and environment variables to unauthorized parties. Such an instance was found to be part of the default Back Office setup.
+
+### Affected modules
+
+- `spryker/setup`: < 4.8.0
+- `spryker/maintenance`: < 3.6.0
+
+### Fix the vulnerability
+
+Update the `spryker/setup` package to version 4.8.0 or higher:
+
+```bash
+composer update spryker/setup:"^4.8.0"
+composer show spryker/setup # Verify the version
+```
+
+Update the `spryker/maintenance` package to version 4.0.0 or higher:
+
+```bash
+composer update spryker/maintenance:"^4.0.0"
+composer show spryker/maintenance # Verify the version
+```
+
 
 ## Efficient and Flexible Cloud Foundation
 

--- a/docs/about/all/releases/security-releases/security-release-notes-202603.0.md
+++ b/docs/about/all/releases/security-releases/security-release-notes-202603.0.md
@@ -10,32 +10,6 @@ This document describes the security-related issues that have been recently reso
 
 For additional support with this content, [contact our support](https://support.spryker.com/). If you found a new security vulnerability, contact us at [security@spryker.com](mailto:security@spryker.com).
 
-
-## Information disclosure via phpinfo() method
-
-Instances of phpinfo() were identified in the codebase, which could potentially expose sensitive configuration details and environment variables to unauthorized parties. Such an instance was found to be part of the default Back Office setup.
-
-### Affected modules
-
-- `spryker/setup`: < 4.8.0
-- `spryker/maintenance`: < 3.6.0
-
-### Fix the vulnerability
-
-Update the `spryker/setup` package to version 4.8.0 or higher:
-
-```bash
-composer update spryker/setup:"^4.8.0"
-composer show spryker/setup # Verify the version
-```
-
-Update the `spryker/maintenance` package to version 4.0.0 or higher:
-
-```bash
-composer update spryker/maintenance:"^4.0.0"
-composer show spryker/maintenance # Verify the version
-```
-
 ## Data storage inconsistency
 
 A data storage inconsistency was identified where certain sensitive data was being written to an additional database table beyond its intended storage location. Although the data was properly encrypted at rest and no exposure occurred, retaining sensitive information in non-designated tables does not align with the principle of data minimization and security best practices.


### PR DESCRIPTION
## PR Description
Describe the context for your changes and the changes you've made.

## Tickets
If changes are associated with a ticket, add a docs ticket here.


## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
- [x] I validated and improved the content with [Custom GPT](https://chatgpt.com/g/g-691b3026738081918f2785ae6267faab-spryker-doc-genius)
- [x] I checked my pages at the deployment preview website.
- [x] I invited a person to review and merge this PR.
