### PR TITLE
CC-37538 Mark ShipmentsRestApi as Migrated in API Platform migration status

### DIFF
--- a/docs/dg/dev/acp/integrate-acp-payment-apps-with-spryker-oms-configuration.md
+++ b/docs/dg/dev/acp/integrate-acp-payment-apps-with-spryker-oms-configuration.md
@@ -144,7 +144,11 @@ For example, if an order gets stuck in the `payment capture pending` state, a Ba
 
 ### Payment operation commands
 
+<<<<<<< Updated upstream
 The following default commands are triggered from OMS to instruct the Payment App on the next steps:
+=======
+The following commands have to be triggered from your OMS to tell the Payment App what to do next. 
+>>>>>>> Stashed changes
 
 - `Payment/Capture`
 - `Payment/Cancel`

--- a/docs/dg/dev/acp/integrate-acp-payment-apps-with-spryker-oms-configuration.md
+++ b/docs/dg/dev/acp/integrate-acp-payment-apps-with-spryker-oms-configuration.md
@@ -144,11 +144,7 @@ For example, if an order gets stuck in the `payment capture pending` state, a Ba
 
 ### Payment operation commands
 
-<<<<<<< Updated upstream
 The following default commands are triggered from OMS to instruct the Payment App on the next steps:
-=======
-The following commands have to be triggered from your OMS to tell the Payment App what to do next. 
->>>>>>> Stashed changes
 
 - `Payment/Capture`
 - `Payment/Cancel`

--- a/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
+++ b/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
@@ -116,7 +116,7 @@ All StorefrontAPI and Extension-only StorefrontAPI modules. Migrated modules are
 | CatalogSearchRestApi | StorefrontAPI | Migrated | GET /catalog-search<br>GET /catalog-search-suggestions |
 | CategoriesRestApi | StorefrontAPI | Migrated | GET /category-trees<br>GET /category-nodes/{id} |
 | CheckoutRestApi | StorefrontAPI | Migrated | POST /checkout-data<br>POST /checkout |
-| CmsPagesRestApi | StorefrontAPI | Migrated  | GET /cms-pages<br>GET /cms-pages/{id} |
+| CmsPagesRestApi | StorefrontAPI | Migrated | GET /cms-pages<br>GET /cms-pages/{id} |
 | CompaniesRestApi | StorefrontAPI | Migrated | GET /companies<br>GET /companies/{id} |
 | CompanyBusinessUnitAddressesRestApi | StorefrontAPI | Migrated | GET /company-business-unit-addresses<br>GET /company-business-unit-addresses/{id} |
 | CompanyBusinessUnitsRestApi | StorefrontAPI | Migrated | GET /company-business-units<br>GET /company-business-units/{id} |
@@ -174,9 +174,9 @@ All StorefrontAPI and Extension-only StorefrontAPI modules. Migrated modules are
 | ServicePointCartsRestApi | Extension-only StorefrontAPI | Planned  | CheckoutRestApi |
 | ServicePointsRestApi | StorefrontAPI | Planned  | GET /service-points<br>GET /service-points/{id}<br>GET /service-points/{id}/service-point-addresses/{id} |
 | SharedCartsRestApi | StorefrontAPI | Planned  | POST /carts/{id}/shared-carts<br>PATCH,DELETE /shared-carts/{id} |
-| ShipmentTypeServicePointsRestApi | Extension-only StorefrontAPI | Migrated  | CheckoutRestApi, ShipmentsRestApi, ShipmentTypesRestApi |
-| ShipmentTypesRestApi | StorefrontAPI | Migrated  | GET /shipment-types<br>GET /shipment-types/{id} |
-| ShipmentsRestApi | Extension-only StorefrontAPI | Planned  | CheckoutRestApi, OrdersRestApi, QuoteRequestsRestApi |
+| ShipmentTypeServicePointsRestApi | Extension-only StorefrontAPI | Migrated | CheckoutRestApi, ShipmentsRestApi, ShipmentTypesRestApi |
+| ShipmentTypesRestApi | StorefrontAPI | Migrated | GET /shipment-types<br>GET /shipment-types/{id} |
+| ShipmentsRestApi | Extension-only StorefrontAPI | Migrated | CheckoutRestApi, OrdersRestApi, QuoteRequestsRestApi |
 | ShoppingListsRestApi | StorefrontAPI | Planned  | GET,POST /shopping-lists<br>GET,PATCH,DELETE /shopping-lists/{id}<br>POST /shopping-lists/{id}/shopping-list-items<br>PATCH,DELETE /shopping-lists/{id}/shopping-list-items/{id} |
 | TaxAppRestApi | StorefrontAPI | Planned  | POST /tax-id-validate |
 | UpSellingProductsRestApi | StorefrontAPI | Planned  | GET /carts/{id}/up-selling-products<br>GET /guest-carts/{id}/up-selling-products |

--- a/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
+++ b/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
@@ -164,19 +164,19 @@ All StorefrontAPI and Extension-only StorefrontAPI modules. Migrated modules are
 | ProductOfferShoppingListsRestApi | Extension-only StorefrontAPI | Planned  | (transfer-only) |
 | ProductOffersRestApi | Extension-only StorefrontAPI | Planned  | ProductsRestApi |
 | ProductOptionsRestApi | Extension-only StorefrontAPI | Planned  | CartsRestApi, OrdersRestApi, ProductsRestApi, QuoteRequestsRestApi |
-| ProductReviewsRestApi | StorefrontAPI | Migrated  | GET,POST /abstract-products/{id}/product-reviews<br>GET /abstract-products/{id}/product-reviews/{id} |
+| ProductReviewsRestApi | StorefrontAPI | Migrated | GET,POST /abstract-products/{id}/product-reviews<br>GET /abstract-products/{id}/product-reviews/{id} |
 | QuoteRequestAgentsRestApi | StorefrontAPI | Migrated | GET,POST /agent-quote-requests<br>GET,PATCH /agent-quote-requests/{id}<br>POST /agent-quote-requests/{id}/agent-quote-request-cancel<br>POST /agent-quote-requests/{id}/agent-quote-request-revise<br>POST /agent-quote-requests/{id}/agent-quote-request-send-to-customer |
 | QuoteRequestsRestApi | StorefrontAPI | Migrated | GET,POST /quote-requests<br>GET,PATCH /quote-requests/{id}<br>POST /quote-requests/{id}/quote-request-cancel<br>POST /quote-requests/{id}/quote-request-revise<br>POST /quote-requests/{id}/quote-request-send-to-user<br>POST /quote-requests/{id}/quote-request-convert-to-quote |
 | RelatedProductsRestApi | StorefrontAPI | Migrated | GET /abstract-products/{id}/related-products |
 | SalesOrderThresholdsRestApi | Extension-only StorefrontAPI | Planned  | CartsRestApi, CheckoutRestApi |
-| SalesReturnsRestApi | StorefrontAPI | Migrated  | GET /return-reasons<br>GET,POST /returns<br>GET /returns/{id} |
+| SalesReturnsRestApi | StorefrontAPI | Migrated | GET /return-reasons<br>GET,POST /returns<br>GET /returns/{id} |
 | SecurityBlockerRestApi | Extension-only StorefrontAPI | Planned  | GlueApplication |
-| ServicePointCartsRestApi | Extension-only StorefrontAPI | Migrated  | CheckoutRestApi |
-| ServicePointsRestApi | StorefrontAPI | Migrated  | GET /service-points<br>GET /service-points/{id}<br>GET /service-points/{id}/service-point-addresses/{id} |
+| ServicePointCartsRestApi | Extension-only StorefrontAPI | Migrated | CheckoutRestApi |
+| ServicePointsRestApi | StorefrontAPI | Migrated | GET /service-points<br>GET /service-points/{id}<br>GET /service-points/{id}/service-point-addresses/{id} |
 | SharedCartsRestApi | StorefrontAPI | Planned  | POST /carts/{id}/shared-carts<br>PATCH,DELETE /shared-carts/{id} |
 | ShipmentTypeServicePointsRestApi | Extension-only StorefrontAPI | Migrated | CheckoutRestApi, ShipmentsRestApi, ShipmentTypesRestApi |
 | ShipmentTypesRestApi | StorefrontAPI | Migrated | GET /shipment-types<br>GET /shipment-types/{id} |
-| ShipmentsRestApi | Extension-only StorefrontAPI | Planned  | CheckoutRestApi, OrdersRestApi, QuoteRequestsRestApi |
+| ShipmentsRestApi | Extension-only StorefrontAPI | Migrated | CheckoutRestApi, OrdersRestApi, QuoteRequestsRestApi |
 | ShoppingListsRestApi | StorefrontAPI | Planned  | GET,POST /shopping-lists<br>GET,PATCH,DELETE /shopping-lists/{id}<br>POST /shopping-lists/{id}/shopping-list-items<br>PATCH,DELETE /shopping-lists/{id}/shopping-list-items/{id} |
 | TaxAppRestApi | StorefrontAPI | Planned  | POST /tax-id-validate |
 | UpSellingProductsRestApi | StorefrontAPI | Planned  | GET /carts/{id}/up-selling-products<br>GET /guest-carts/{id}/up-selling-products |

--- a/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
+++ b/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
@@ -1,7 +1,7 @@
 ---
 title: Migration status - Glue API to API Platform
 description: Tracks the migration status of API modules to the Spryker API Platform across StorefrontAPI and BackendAPI, with endpoint coverage and a high-level migration workflow.
-last_updated: May 14, 2026
+last_updated: May 19, 2026
 template: howto-guide-template
 redirect_from:
   - /docs/dg/dev/upgrade-and-migrate/glue-api-migration-status.html
@@ -176,7 +176,7 @@ All StorefrontAPI and Extension-only StorefrontAPI modules. Migrated modules are
 | SharedCartsRestApi | StorefrontAPI | Planned  | POST /carts/{id}/shared-carts<br>PATCH,DELETE /shared-carts/{id} |
 | ShipmentTypeServicePointsRestApi | Extension-only StorefrontAPI | Planned  | CheckoutRestApi, ShipmentsRestApi, ShipmentTypesRestApi |
 | ShipmentTypesRestApi | StorefrontAPI | Planned  | GET /shipment-types<br>GET /shipment-types/{id} |
-| ShipmentsRestApi | Extension-only StorefrontAPI | Planned  | CheckoutRestApi, OrdersRestApi, QuoteRequestsRestApi |
+| ShipmentsRestApi | Extension-only StorefrontAPI | Migrated | CheckoutRestApi, OrdersRestApi, QuoteRequestsRestApi |
 | ShoppingListsRestApi | StorefrontAPI | Planned  | GET,POST /shopping-lists<br>GET,PATCH,DELETE /shopping-lists/{id}<br>POST /shopping-lists/{id}/shopping-list-items<br>PATCH,DELETE /shopping-lists/{id}/shopping-list-items/{id} |
 | TaxAppRestApi | StorefrontAPI | Planned  | POST /tax-id-validate |
 | UpSellingProductsRestApi | StorefrontAPI | Planned  | GET /carts/{id}/up-selling-products<br>GET /guest-carts/{id}/up-selling-products |


### PR DESCRIPTION
## Summary

- Flips `ShipmentsRestApi` row in `docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md` from `Planned` to `Migrated` — delivered by [spryker/suite#622](https://github.com/spryker/suite/pull/622) (CC-37538), which adds `shipments.resource.yml` and `ShipmentMethodsByShipmentRelationshipResolver` in `ShipmentsRestApi`.
- Bumps `last_updated` to May 19, 2026.

## Ticket

https://spryker.atlassian.net/browse/CC-37538

## Test plan

- [ ] Visual check that the `ShipmentsRestApi` row in the rendered Migration status page shows `Migrated`.

[CC-37538]: https://spryker.atlassian.net/browse/CC-37538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ