### PR TITLE
Security: add CVE-2026-46633 Twig PHP code injection to 202605.0 release notes

### DIFF
--- a/docs/about/all/releases/security-releases/security-release-notes-202605.0.md
+++ b/docs/about/all/releases/security-releases/security-release-notes-202605.0.md
@@ -152,11 +152,9 @@ console publish:trigger-events -r file
 ```
 
 
-## PHP code injection via Twig template name (CVE-2026-46633)
+## PHP code injection via Twig template name
 
 The `Compiler::string()` method in Twig failed to escape single quotes when generating PHP double-quoted string literals. An attacker could craft a template name containing a single quote to terminate the surrounding PHP string early, injecting arbitrary PHP expressions into the compiled Twig cache file. The injected code executes when the cache file is loaded, bypassing the Twig sandbox and enabling remote code execution. Because `SecurityPolicy` permits `{% raw %}{% use %}{% endraw %}` tags in sandboxed templates, this vulnerability is exploitable even in restricted environments.
-
-For more information, see [GHSA-7p85-w9px-jpjp](https://github.com/advisories/GHSA-7p85-w9px-jpjp).
 
 ### Affected modules
 

--- a/docs/about/all/releases/security-releases/security-release-notes-202605.0.md
+++ b/docs/about/all/releases/security-releases/security-release-notes-202605.0.md
@@ -1,7 +1,7 @@
 ---
 title: Security release notes 202605.0
 description: Security updates released for version 202605.0
-last_updated: May 28, 2026
+last_updated: May 29, 2026
 template: concept-topic-template
 publish_date: "2026-05-18"
 ---
@@ -149,4 +149,25 @@ class FileManagerConfig extends SprykerFileManagerConfig
 
 ```bash
 console publish:trigger-events -r file
+```
+
+
+## PHP code injection via Twig template name (CVE-2026-46633)
+
+The `Compiler::string()` method in Twig failed to escape single quotes when generating PHP double-quoted string literals. An attacker could craft a template name containing a single quote to terminate the surrounding PHP string early, injecting arbitrary PHP expressions into the compiled Twig cache file. The injected code executes when the cache file is loaded, bypassing the Twig sandbox and enabling remote code execution. Because `SecurityPolicy` permits `{% raw %}{% use %}{% endraw %}` tags in sandboxed templates, this vulnerability is exploitable even in restricted environments.
+
+For more information, see [GHSA-7p85-w9px-jpjp](https://github.com/advisories/GHSA-7p85-w9px-jpjp).
+
+### Affected modules
+
+- `twig/twig`: < 3.26.0
+- `spryker/twig`: < 3.31.0
+
+### Fix the vulnerability
+
+Update the affected packages:
+
+```bash
+composer update twig/twig:"^3.26.0" spryker/twig:"^3.31.0"
+composer show twig/twig spryker/twig # Verify the versions
 ```


### PR DESCRIPTION
## Summary

- Added a new vulnerability entry for **CVE-2026-46633** (GHSA-7p85-w9px-jpjp) to the 202605.0 security release notes
- Updated `last_updated` date to May 29, 2026
- Ticket https://spryker.atlassian.net/browse/CC-38944

## Related

- Advisory: https://github.com/advisories/GHSA-7p85-w9px-jpjp
- Docs page: https://docs.spryker.com/docs/about/all/releases/security-releases/security-release-notes-202605.0.html

## Changes

- Updated: `docs/about/all/releases/security-releases/security-release-notes-202605.0.md`
  - Added section: *PHP code injection via Twig template name (CVE-2026-46633)*
  - Affected modules: `twig/twig < 3.26.0`, `spryker/twig < 3.31.0`
  - Resolution: `composer update twig/twig:"^3.26.0" spryker/twig:"^3.31.0"`