### PR TITLE
CC-39117: Document AI Pricing configuration and Audit Logs cost estimator

### DIFF
--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.md
@@ -170,7 +170,7 @@ To display estimated costs in the Audit Logs, configure token prices per provide
 
 AI Vendor model token pricing uses the AI Vendor configuration feature (`ai_vendor.configuration.yml`). Token prices are expressed in USD per 1,000,000 tokens and are configured separately for input and output tokens for each model.
 
-### Sync the AI Pricing configuration
+### Sync the AI Vendor configuration
 
 Before pricing settings appear in the Back Office, run:
 
@@ -180,7 +180,7 @@ console configuration:sync
 
 ### Configure prices per provider
 
-In the Back Office, go to **Configuration > Manage > AI Pricing** and select a provider tab (OpenAI, Anthropic, or AWS Bedrock). Enter the input and output token prices for each model as a JSON object:
+In the Back Office, go to **Configuration > Manage > AI Vendor** and select a provider tab (OpenAI, Anthropic, or AWS Bedrock). Enter the input and output token prices for each model as a JSON object:
 
 ```json
 {"gpt-4.1": {"input": 2.50, "output": 10.00}, "gpt-4o-mini": {"input": 0.15, "output": 0.60}}

--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.md
@@ -1,7 +1,7 @@
 ---
 title: AI Foundation Audit Logs
 description: Track and audit AI interactions with the AiFoundation module audit logging feature, including estimated cost per interaction.
-last_updated: Jun 4, 2026
+last_updated: Jun 8, 2026
 keywords: audit, logging, ai, foundation, tracking, compliance, ai interactions, monitoring, cost estimation, ai pricing
 template: howto-guide-template
 label: early-access
@@ -185,6 +185,20 @@ In the Back Office, go to **Configuration > Manage > AI Pricing** and select a p
 ```json
 {"gpt-4.1": {"input": 2.50, "output": 10.00}, "gpt-4o-mini": {"input": 0.15, "output": 0.60}}
 ```
+
+You can optionally include a `"currency"` code per model entry, which is appended to the displayed cost:
+
+```json
+{"gpt-4.1": {"input": 2.50, "output": 10.00, "currency": "USD"}}
+```
+
+The module ships with default prices for common models. Verify these against current provider pricing before using them in production:
+
+| Provider | Default models included |
+|----------|------------------------|
+| OpenAI | `gpt-4.1`, `gpt-4.1-mini`, `gpt-4o`, `gpt-4o-mini` |
+| Anthropic | `claude-opus-4`, `claude-sonnet-4-5`, `claude-haiku-4-5` |
+| AWS Bedrock | `eu.anthropic.claude-sonnet-4-5-20250929-v1:0`, `eu.anthropic.claude-haiku-4-5-20251001-v1:0` |
 
 Price key format per provider:
 

--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.md
@@ -1,8 +1,8 @@
 ---
 title: AI Foundation Audit Logs
-description: Track and audit AI interactions with the AiFoundation module audit logging feature
-last_updated: Apr 22, 2026
-keywords: audit, logging, ai, foundation, tracking, compliance, ai interactions, monitoring
+description: Track and audit AI interactions with the AiFoundation module audit logging feature, including estimated cost per interaction.
+last_updated: Jun 4, 2026
+keywords: audit, logging, ai, foundation, tracking, compliance, ai interactions, monitoring, cost estimation, ai pricing
 template: howto-guide-template
 label: early-access
 related:
@@ -26,8 +26,10 @@ After [enabling audit logging](#enable-audit-logging), you can view and analyze 
 
 The Audit Logs page provides:
 
-- **Summary statistics cards**: Total requests, total tokens consumed, success rate, and average inference time for the filtered dataset.
-- **Filterable data table**: Filter logs by configuration name, status (success/failed), conversation reference, and date range.
+- **Summary statistics cards**: Total requests, total tokens consumed, success rate, average inference time, and total estimated cost (USD) for the filtered dataset.
+- **Filterable data table**: Filter logs by configuration name, status (success/failed), conversation reference, and date range. Each row shows an estimated cost (USD) when token prices are configured.
+- **Cost breakdown**: A per-provider and per-model breakdown of estimated costs, respecting active filters.
+- **Unpriced interaction notice**: When provider/model combinations have no configured price, the page lists them with request counts so you know exactly which prices to add.
 - **Detail drawer**: Click a row's prompt to view complete prompt and response text, token breakdown, metadata, and error details.
 
 ### Navigation setup
@@ -65,6 +67,7 @@ The AiFoundation audit logging system automatically captures detailed informatio
 - **Prompt and Response Data**: The user prompt and AI response messages
 - **Token Usage**: Input and output token counts for cost tracking
 - **Performance Metrics**: Inference time in milliseconds
+- **Estimated Cost**: Per-interaction cost in USD, calculated from configured token prices at display time
 - **Metadata**: Tool invocations, errors, and structured schema information
 - **Conversation Tracking**: Links to conversation references for multi-turn conversations
 - **Status**: Success or failure status of each interaction
@@ -161,6 +164,83 @@ Run the database migrations to create the `spy_ai_interaction_log` table:
 console propel:install
 ```
 
+## Configure AI token pricing
+
+To display estimated costs in the Audit Logs, configure token prices per provider and model in the Back Office under **Configuration > Manage > AI Pricing**.
+
+AI Pricing configuration uses the AI Vendor configuration feature (`ai_vendor.configuration.yml`). Token prices are expressed in USD per 1,000,000 tokens and are configured separately for input and output tokens for each model.
+
+### Sync the AI Pricing configuration
+
+Before pricing settings appear in the Back Office, run:
+
+```bash
+console configuration:sync
+```
+
+### Configure prices per provider
+
+In the Back Office, go to **Configuration > Manage > AI Pricing** and select a provider tab (OpenAI, Anthropic, or AWS Bedrock). Enter the input and output token prices for each model as a JSON object:
+
+```json
+{"gpt-4.1": {"input": 2.50, "output": 10.00}, "gpt-4o-mini": {"input": 0.15, "output": 0.60}}
+```
+
+Price key format per provider:
+
+| Provider | Example model key |
+|----------|------------------|
+| OpenAI | `gpt-4.1`, `gpt-4o-mini` |
+| Anthropic | `claude-sonnet-4-5`, `claude-haiku-4-5` |
+| AWS Bedrock | `eu.anthropic.claude-sonnet-4-5-20250929-v1:0` |
+
+Models not listed in the configuration are shown as **N/A** in the Audit Logs and are excluded from cost totals.
+
+### Override the provider-to-tab mapping
+
+By default, the module maps logged provider names to pricing tabs as follows:
+
+| Logged provider name | Pricing tab |
+|----------------------|-------------|
+| `openai` | `openai` |
+| `anthropic` | `anthropic` |
+| `bedrock` | `aws` |
+
+To add pricing support for additional providers, override `getProviderPricingTabMap()` in `AiFoundationConfig`:
+
+```php
+<?php
+
+namespace Pyz\Zed\AiFoundation;
+
+use Spryker\Zed\AiFoundation\AiFoundationConfig as SprykerAiFoundationConfig;
+
+class AiFoundationConfig extends SprykerAiFoundationConfig
+{
+    /**
+     * @return array<string, string>
+     */
+    public function getProviderPricingTabMap(): array
+    {
+        return array_merge(parent::getProviderPricingTabMap(), [
+            'my-custom-provider' => 'my-custom-tab',
+        ]);
+    }
+}
+```
+
+### Cost estimation notes
+
+{% info_block warningBox "Cost estimates" %}
+
+All cost figures displayed in the Audit Logs are **estimates** based on the token prices you configure. They may overestimate actual spend for non-Anthropic providers because cached input tokens, which are billed at a lower rate, are not reported separately by the AI library. Costs reflect the currently configured prices applied at display time — changing a price retroactively updates all historical rows.
+
+{% endinfo_block %}
+
+- Prices are applied **at display time**: no per-row price snapshot is stored. Changing a price revalues all historical interactions.
+- Per-row costs are rounded to **4 decimal places**; aggregated totals are rounded to **2 decimal places**.
+- A provider/model combination with a malformed stored price value is treated as unpriced (shown as **N/A**), not as zero cost.
+
 ## Understanding AI interaction log data
 
 ### AiInteractionLog transfer properties
@@ -177,6 +257,7 @@ Each logged AI interaction contains the following information:
 | `response` | string | AI response message |
 | `inputTokens` | int | Input token count |
 | `outputTokens` | int | Output token count |
+| `estimatedCost` | float | Estimated USD cost; `null` when the provider/model has no configured price |
 | `conversationReference` | string | Conversation reference for multi-turn conversations |
 | `inferenceTimeMs` | int | Inference time in milliseconds |
 | `isSuccessful` | bool | Interaction success status |
@@ -186,7 +267,7 @@ Each logged AI interaction contains the following information:
 ## Best practices
 
 1. **Regular cleanup**: Implement a periodic cleanup process to archive or delete old audit logs if required by your retention policies
-2. **Cost tracking**: Use token counts to monitor and optimize AI usage costs
+2. **Cost tracking**: Configure token prices for all active provider/model combinations to get full cost visibility. The Audit Logs page lists any unpriced combinations with request counts to help you identify gaps.
 3. **Performance monitoring**: Track inference times to identify slow interactions
 4. **Error analysis**: Review failed interactions to improve prompts and error handling
 5. **Metadata inspection**: Store and analyze metadata to understand tool invocations and structured responses

--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.md
@@ -1,7 +1,7 @@
 ---
 title: AI Foundation Audit Logs
 description: Track and audit AI interactions with the AiFoundation module audit logging feature, including estimated cost per interaction.
-last_updated: Jun 10, 2026
+last_updated: Jun 12, 2026
 keywords: audit, logging, ai, foundation, tracking, compliance, ai interactions, monitoring, cost estimation, ai pricing
 template: howto-guide-template
 label: early-access
@@ -164,7 +164,7 @@ Run the database migrations to create the `spy_ai_interaction_log` table:
 console propel:install
 ```
 
-## Configure AI token pricing
+## Configure AI Vendor model token pricing
 
 To display estimated costs in the Audit Logs, configure token prices per provider and model.
 
@@ -180,7 +180,7 @@ console configuration:sync
 
 ### Configure prices per provider
 
-In the Back Office, go to **Configuration > Manage > AI Vendor** and select a provider tab (OpenAI, Anthropic, or AWS Bedrock). Enter the input and output token prices for each model as a JSON object:
+In the Back Office, go to **Configuration > Manage** and select the **AI Vendor** tab for the provider (OpenAI, Anthropic, or AWS Bedrock). Enter the input and output token prices for each model as a JSON object:
 
 ```json
 {"gpt-4.1": {"input": 2.50, "output": 10.00}, "gpt-4o-mini": {"input": 0.15, "output": 0.60}}

--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.md
@@ -1,7 +1,7 @@
 ---
 title: AI Foundation Audit Logs
 description: Track and audit AI interactions with the AiFoundation module audit logging feature, including estimated cost per interaction.
-last_updated: Jun 8, 2026
+last_updated: Jun 10, 2026
 keywords: audit, logging, ai, foundation, tracking, compliance, ai interactions, monitoring, cost estimation, ai pricing
 template: howto-guide-template
 label: early-access
@@ -166,9 +166,9 @@ console propel:install
 
 ## Configure AI token pricing
 
-To display estimated costs in the Audit Logs, configure token prices per provider and model in the Back Office under **Configuration > Manage > AI Pricing**.
+To display estimated costs in the Audit Logs, configure token prices per provider and model.
 
-AI Pricing configuration uses the AI Vendor configuration feature (`ai_vendor.configuration.yml`). Token prices are expressed in USD per 1,000,000 tokens and are configured separately for input and output tokens for each model.
+AI Vendor model token pricing uses the AI Vendor configuration feature (`ai_vendor.configuration.yml`). Token prices are expressed in USD per 1,000,000 tokens and are configured separately for input and output tokens for each model.
 
 ### Sync the AI Pricing configuration
 
@@ -199,14 +199,6 @@ The module ships with default prices for common models. Verify these against cur
 | OpenAI | `gpt-4.1`, `gpt-4.1-mini`, `gpt-4o`, `gpt-4o-mini` |
 | Anthropic | `claude-opus-4`, `claude-sonnet-4-5`, `claude-haiku-4-5` |
 | AWS Bedrock | `eu.anthropic.claude-sonnet-4-5-20250929-v1:0`, `eu.anthropic.claude-haiku-4-5-20251001-v1:0` |
-
-Price key format per provider:
-
-| Provider | Example model key |
-|----------|------------------|
-| OpenAI | `gpt-4.1`, `gpt-4o-mini` |
-| Anthropic | `claude-sonnet-4-5`, `claude-haiku-4-5` |
-| AWS Bedrock | `eu.anthropic.claude-sonnet-4-5-20250929-v1:0` |
 
 Models not listed in the configuration are shown as **N/A** in the Audit Logs and are excluded from cost totals.
 


### PR DESCRIPTION
## Summary

- Updated the AI Foundation Audit Logs page to document the new cost estimation feature introduced in CC-39017.
- Added a new **Configure AI token pricing** section covering how to sync configuration, set per-model prices for OpenAI, Anthropic, and AWS Bedrock, override the provider-to-tab mapping, and understand cost estimation caveats.
- Extended the Audit Logs page overview and statistics cards description to reflect the new estimated cost columns and breakdown panel.
- Added `estimatedCost` to the `AiInteractionLog` transfer properties table.
- Updated the **Best practices** section to include guidance on configuring prices for all active providers.

## Related

- Implementation PR: https://github.com/spryker/suite/pull/712
- Ticket: [CC-39117](https://spryker.atlassian.net/browse/CC-39017)

## Changes

- Updated: `docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.md`

[CC-39117]: https://spryker.atlassian.net/browse/CC-39117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ