### PR TITLE
Fix broken B2B Demo Marketplace URL at "Architecture as Code" page

### DIFF
--- a/docs/dg/dev/architecture/architecture-as-code.md
+++ b/docs/dg/dev/architecture/architecture-as-code.md
@@ -19,7 +19,7 @@ Spryker ships the architecture/ folder with a complete Architecture as Code stru
 
 {% info_block infoBox "Existing projects" %}
 
-If your project is based on a Spryker release before 202602.0, refer to the [Spryker B2B Demo Marketplace](https://github.com/spryker/b2b-demo-marketplace) master branch source code to see how the Architecture as Code structure is implemented and to copy the "architecture/" folder into your project.
+If your project is based on a Spryker release before 202602.0, refer to the [Spryker B2B Demo Marketplace](https://github.com/spryker-shop/b2b-demo-marketplace) master branch source code to see how the Architecture as Code structure is implemented and to copy the "architecture/" folder into your project.
 
 {% endinfo_block %}
 

--- a/docs/dg/dev/architecture/architecture-as-code.md
+++ b/docs/dg/dev/architecture/architecture-as-code.md
@@ -2,7 +2,7 @@
 title: Architecture as Code
 description: Learn how to implement Architecture as Code in your Spryker project using industry standards like arc42, C4 Model, and diagrams-as-code to maintain living, version-controlled documentation.
 keywords: Architecture as Code,arc42,C4 Model,diagrams-as-code,diagram
-last_updated: Apr 22, 2026
+last_updated: Jun 5, 2026
 template: concept-topic-template
 related:
   - title: Architectural Convention


### PR DESCRIPTION
## PR Description
Fixed URL

## Tickets
If changes are associated with a ticket, add a docs ticket here.


## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
- [x] I validated and improved the content with [Custom GPT](https://chatgpt.com/g/g-691b3026738081918f2785ae6267faab-spryker-doc-genius)
- [x] I checked my pages at the deployment preview website.
- [x] I invited a person to review and merge this PR.
