### PR TITLE
CC-39167: Remove deprecated prompts and outdated commands from AI Dev SDK docs

### DIFF
--- a/docs/dg/dev/ai/ai-dev/ai-dev-mcp-server.md
+++ b/docs/dg/dev/ai/ai-dev/ai-dev-mcp-server.md
@@ -1,7 +1,7 @@
 ---
 title: AI Dev MCP Server
 description: Set up and configure the Model Context Protocol server for AI assistant integration
-last_updated: Dec 9, 2025
+last_updated: Jun 9, 2026
 label: early-access
 keywords: ai, mcp, model context protocol, claude, copilot, ai-dev, configuration
 template: howto-guide-template
@@ -11,8 +11,8 @@ This document describes how to configure and use the AiDev MCP server to connect
 
 ## About Model Context Protocol (MCP)
 
-The Model Context Protocol (MCP) is an open-source standard for connecting AI applications to external systems. 
-For Spryker developers, MCP allows AI assistants like Claude or Copilot to understand your project improving the quality of AI-generated code and recommendations.
+The Model Context Protocol (MCP) is an open-source standard for connecting AI applications to external systems.
+For Spryker developers, MCP allows AI assistants like Claude or Copilot to understand your project, improving the quality of AI-generated code and recommendations.
 
 Learn more about MCP at [modelcontextprotocol.io](https://modelcontextprotocol.io/docs/getting-started/intro).
 
@@ -38,13 +38,12 @@ Navigate to your Spryker project directory and run:
 claude mcp add spryker-project "$(pwd)/docker/sdk console ai-dev:mcp-server -q"
 ```
 
-This command will:
-- Add the MCP server configuration to Claude Code
-- Use the current project directory path automatically
-- Configure the server to run in quiet mode
+This command:
+- Adds the MCP server configuration to Claude Code
+- Uses the current project directory path automatically
+- Configures the server to run in quiet mode
 
-Claude Code will now have access to Spryker-specific tools and prompts through the MCP server.
-![MCP prompts](https://spryker.s3.eu-central-1.amazonaws.com/docs/dg/dev/ai-dev/MCP-prompts.png)
+Claude Code will now have access to Spryker-specific tools through the MCP server.
 ![MCP claude code](https://spryker.s3.eu-central-1.amazonaws.com/docs/dg/dev/ai-dev/mcp-tool-claude-code.png)
 
 ### Claude Desktop
@@ -77,7 +76,7 @@ For Claude Desktop application, configure the MCP server in the application sett
 For GitHub Copilot Chat in PHPStorm with MCP support (requires PHPStorm 2024.3+):
 
 1. Open PHPStorm Settings/Preferences
-2. Navigate to **Tools � GitHub Copilot � MCP Servers**
+2. Navigate to **Tools > GitHub Copilot > MCP Servers**
 3. Add a new server configuration with the following JSON:
 
 ```json
@@ -129,64 +128,3 @@ The AiDev module provides the following built-in tools that AI assistants can us
 
 AI assistants can automatically discover and use these tools when connected to the MCP server.
 
-## MCP prompts
-
-The AiDev module provides contextual prompts to help AI assistants understand Spryker-specific concepts and patterns.
-
-### Default prompts
-
-By default, prompts are automatically downloaded from the [Spryker Prompt Library](https://github.com/spryker-dev/prompt-library) when you run the MCP server for the first time. These prompts include:
-- Spryker architecture patterns
-- Module structure guidelines
-- Development best practices
-- Common workflows and conventions
-
-The prompts are generated and stored in: `src/Generated/Shared/Prompts/`
-
-### Custom prompts
-
-You can extend the default prompts by adding custom prompt files to the prompts directory:
-
-```text
-PROJECT_ROOT/data/prompts/
-```
-
-To add custom prompts:
-
-1. Create the prompts directory if it doesn't exist:
-   
-```bash
-mkdir -p data/prompts
-```
-
-2. Add your custom prompt markdown file `data/prompts/custom-prompt.md` to this directory with the following structure:
-
-```md
----
-title: prompt name
-description: short description
----
-
-prompt content ...
-```
-
-3. Regenerate prompts to include your custom ones:
-
-```bash
-docker/sdk console ai-dev:generate-prompts
-```
-
-Custom prompts should be written in Markdown format and follow the same structure as the default prompts from the Prompt Library. They will be converted into PHP classes and made available to AI assistants through the MCP server.
-
-### Managing prompts
-
-To manually regenerate prompts from the Prompt Library and your custom prompts:
-
-```bash
-docker/sdk console ai-dev:generate-prompts
-```
-
-This command will:
-- Fetch the latest prompts from the configured Prompt Library repository
-- Process any custom prompts in `data/prompts/`
-- Generate PHP prompt classes in `src/Generated/Shared/Prompts/`

--- a/docs/dg/dev/ai/ai-dev/ai-dev-overview.md
+++ b/docs/dg/dev/ai/ai-dev/ai-dev-overview.md
@@ -1,9 +1,9 @@
 ---
 title: AI Dev SDK Overview
 description: Integrate AI development tools and MCP server into your Spryker application
-last_updated: May 21, 2026
+last_updated: Jun 9, 2026
 label: early-access
-keywords: ai, development, mcp, model context protocol, ai-dev, tools, prompts, extension
+keywords: ai, development, mcp, model context protocol, ai-dev, tools, extension
 template: howto-guide-template
 ---
 
@@ -24,14 +24,13 @@ This document describes how to integrate and use the AiDev module to connect you
 
 ## Overview
 
-The AiDev module provides an MCP server that enables AI assistants to interact with your Spryker application. 
-It exposes Spryker-specific information through MCP tools and prompts, allowing AI assistants to better understand and work with your codebase.
+The AiDev module provides an MCP server that enables AI assistants to interact with your Spryker application.
+It exposes Spryker-specific information through MCP tools, allowing AI assistants to better understand and work with your codebase.
 
 The module includes:
 - **MCP Server**: A console command that runs an MCP server to communicate with AI assistants
-- **Extension Points**: Plugin interfaces for adding custom MCP tools and prompts
+- **Extension Points**: Plugin interfaces for adding custom MCP tools
 - **Built-in Tools**: Pre-configured tools for accessing Spryker transfers, interfaces, and OMS information
-- **Prompt Generation**: Automatic generation of context-aware prompts from documentation
 
 ## Console commands
 
@@ -47,8 +46,7 @@ docker/sdk console ai-dev:mcp-server -q
 
 This command:
 - Starts an MCP server using stdio transport
-- Registers all configured MCP tool and prompt plugins
-- Automatically generates prompts if they do not exist
+- Registers all configured MCP tool plugins
 - Listens for requests from AI assistants
 
 **Usage**: This command is typically configured in AI assistant tools (like Claude Desktop) to enable them to access Spryker-specific information.
@@ -99,21 +97,6 @@ If you use Docker sync, the `/.git*` entry in `.dockersyncignore` also excludes 
 
 **Usage**: Run this command once when setting up AI tooling for a project.
 
-### Generate Prompts Command
-
-The `ai-dev:generate-prompts` command generates MCP prompts from a configured [Prompt Library](https://github.com/spryker-dev/prompt-library).
-
-```bash
-docker/sdk console ai-dev:generate-prompts
-```
-
-This command:
-- Fetches prompts
-- Generates PHP-based prompt classes
-- Stores generated prompts in the configured directory
-
-**Usage**: Use this command when you need to regenerate prompts from updated documentation or when initializing the module for the first time.
-
 ## Claude Code plugin
 
 The AI Dev SDK ships a Claude Code plugin — `spryker-ai-dev-sdk` — through the `spryker-plugins-official` marketplace. The plugin bundles Spryker-aware skills and the `spryker-code-reviewer` subagent. See [Claude Code Plugin](/docs/dg/dev/ai/ai-dev/ai-dev-claude-code-plugin.html) for installation instructions and a full list of capabilities.
@@ -152,43 +135,9 @@ class AiDevDependencyProvider extends SprykerAiDevDependencyProvider
 }
 ```
 
-### AiDevMcpPromptPluginInterface
-
-Implement this interface to add custom MCP prompts that provide context or instructions to AI assistants.
-
-**Interface location**: `SprykerSdk\Zed\AiDev\Dependency\AiDevMcpPromptPluginInterface`
-
-**Integration**: Register your prompt plugins in `AiDevDependencyProvider::getMcpPromptPlugins()`:
-
-```php
-<?php
-
-namespace Pyz\Zed\AiDev;
-
-use SprykerSdk\Zed\AiDev\AiDevDependencyProvider as SprykerAiDevDependencyProvider;
-use Pyz\Zed\AiDev\Communication\Plugins\CustomAiDevMcpPromptPlugin;
-
-class AiDevDependencyProvider extends SprykerAiDevDependencyProvider
-{
-    /**
-     * @return array<\SprykerSdk\Zed\AiDev\Dependency\AiDevMcpPromptPluginInterface>
-     */
-    protected function getMcpPromptPlugins(): array
-    {
-        return [
-            new CustomAiDevMcpPromptPlugin(),
-        ];
-    }
-}
-```
-
 ## Configuration
 
-The AiDev module can be configured through the `AiDevConfig` class. Key configuration options include:
-
-- **Prompt Directory**: Set the directory where generated prompts are stored
-
-Refer to the module's configuration class for available options and their default values.
+The AiDev module can be configured through the `AiDevConfig` class. Refer to the module's configuration class for available options and their default values.
 
 ## Debugging the MCP server
 
@@ -205,7 +154,7 @@ npx @modelcontextprotocol/inspector docker/sdk console ai-dev:mcp-server -q
 This command:
 - Starts the MCP Inspector in your browser
 - Connects to your local MCP server
-- Displays all available tools and prompts
+- Displays all available tools
 - Lets you test tool calls interactively
 
 **With Xdebug:**

--- a/docs/dg/dev/ai/ai-dev/ai-dev.md
+++ b/docs/dg/dev/ai/ai-dev/ai-dev.md
@@ -1,7 +1,7 @@
 ---
 title: AI Dev SDK
 description: Spryker AI Dev SDK
-last_updated: May 21, 2026
+last_updated: Jun 9, 2026
 template: concept-topic-template
 redirect_from:
   - /docs/dg/dev/ai-dev/ai-dev
@@ -21,7 +21,7 @@ The AI Dev SDK provides an MCP server, which is a console command that your AI t
 
 ## How it works
 
-After you install the SDK, [add a simple configuration](/docs/dg/dev/ai/ai-dev/ai-dev-mcp-server.html) to your AI tool. When your Spryker project is running, your AI tool can access Spryker-specific information and prompts through the MCP server.
+After you install the SDK, [add a simple configuration](/docs/dg/dev/ai/ai-dev/ai-dev-mcp-server.html) to your AI tool. When your Spryker project is running, your AI tool can access Spryker-specific information through the MCP server.
 
 ## Result
 
@@ -45,17 +45,13 @@ AI can analyze your OMS flows to find possible next states, transitions, conditi
 
 AI can analyze, modify, and transform multi-column CSV files correctly. This task normally requires significant manual effort.
 
-### Sharing prompts across your team
-
-The SDK includes access to the Spryker prompt library, and you can add your own project-specific prompts. This means your team can reuse effective prompts instead of everyone writing their own.
-
 ### Database queries
 
 AI can execute read-only database queries to inspect data when debugging issues.
 
 ### Extensible for your project
 
-You can extend the MCP server by creating custom plugins (to add new tools) and custom prompts.
+You can extend the MCP server by creating custom plugins to add new tools.
 
 ## Install the AI Dev SDK
 


### PR DESCRIPTION
## Jira ticket

[CC-39167](https://spryker.atlassian.net/browse/CC-39167)

## Summary

- Removes the `ai-dev:generate-prompts` command section and all MCP prompts documentation (default prompts, custom prompts, managing prompts) from `ai-dev-mcp-server.md` and `ai-dev-overview.md` — prompts are no longer supported by the SDK
- Removes the `AiDevMcpPromptPluginInterface` extension point section from `ai-dev-overview.md`
- Removes the "Sharing prompts across your team" capability from `ai-dev.md`
- Removes references to deprecated `GeneratePromptsConsole`, `GenerateSkillsConsole`, and `GenerateAgentsFileConsole` commands from the overview doc
- Cleans up incidental references (keywords, descriptions) that mentioned prompts

## Motivation

The SDK README explicitly states these commands and the prompt system are outdated — their functionality is now delivered through the Claude Code plugin and the `ai-dev:setup` command. Keeping the docs would mislead users into wiring deprecated console commands.

## Test plan

- [ ] Vale: 0 errors
- [ ] Markdownlint: 0 errors
- [ ] All internal links use `/docs/.../*.html` format
- [ ] `last_updated` updated to Jun 9, 2026 on all modified files

[CC-39167]: https://spryker.atlassian.net/browse/CC-39167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ