### PR TITLE
CC-38958: Add "Released In" column to API Platform migration status docs

### DIFF
--- a/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
+++ b/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
@@ -1,7 +1,7 @@
 ---
 title: Migration status - Glue API to API Platform
 description: Tracks the migration status of API modules to the Spryker API Platform across StorefrontAPI and BackendAPI, with endpoint coverage and a high-level migration workflow.
-last_updated: Jun 9, 2026
+last_updated: Jun 10, 2026
 template: howto-guide-template
 redirect_from:
   - /docs/dg/dev/upgrade-and-migrate/glue-api-migration-status.html
@@ -129,7 +129,6 @@ All StorefrontAPI and Extension-only StorefrontAPI modules. Migrated modules are
 | CustomerAccessRestApi | StorefrontAPI | Migrated | 1.3.0 | — | GET /customer-access |
 | CustomersRestApi | StorefrontAPI | Migrated | 1.28.0 | — | GET,POST /customers<br>GET,PATCH,DELETE /customers/{id}<br>GET,POST /customers/{id}/addresses<br>GET,PATCH,DELETE /customers/{id}/addresses/{id}<br>POST /customer-forgotten-password<br>PATCH /customer-restore-password/{id}<br>PATCH /customer-password/{id}<br>POST /customer-confirmation |
 | DiscountPromotionsRestApi | Extension-Only-StorefrontAPI | Migrated | 1.6.0 | CartCodesRestApi, CartsRestApi | (extension-only) |
-| DiscountsRestApi | StorefrontAPI | Migrated | TODO | — | POST /carts/{id}/vouchers<br>DELETE /carts/{id}/vouchers/{id}<br>POST /guest-carts/{id}/vouchers<br>DELETE /guest-carts/{id}/vouchers/{id} |
 | EntityTagsRestApi | Extension-only StorefrontAPI | Migrated | 1.1.0 | — | (extension-only) |
 | GiftCardsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | — | (extension-only) |
 | HealthCheck | StorefrontAPI | Migrated | 1.1.0 | — | GET /health-check |
@@ -138,14 +137,12 @@ All StorefrontAPI and Extension-only StorefrontAPI modules. Migrated modules are
 | MerchantProductOfferWishlistRestApi | Extension-only StorefrontAPI | Migrated | 1.3.0 | WishlistsRestApi | (extension-only) |
 | MerchantProductShoppingListsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | — | (extension-only) |
 | MerchantProductsRestApi | Extension-only StorefrontAPI | Migrated | 1.1.0 | CartsRestApi | (extension-only) |
-| MerchantRelationshipProductListsRestApi | Extension-only StorefrontAPI | Migrated | TODO | CustomersRestApi | (extension-only) |
 | MerchantSalesReturnsRestApi | Extension-only StorefrontAPI | Migrated | 1.1.0 | — | (extension-only) |
 | MerchantShipmentsRestApi | Extension-only StorefrontAPI | Migrated | 0.1.1 | ShipmentsRestApi | (extension-only) |
 | MultiCartsRestApi | Extension-only StorefrontAPI | Migrated | 1.1.0 | CartsRestApi | (extension-only) |
 | MultiFactorAuth | StorefrontAPI | Migrated | 2.5.0 | — | GET /multi-factor-auth-types, POST /multi-factor-auth-trigger, POST /multi-factor-auth-type-activate, POST /multi-factor-auth-type-verify, POST /multi-factor-auth-type-deactivate |
 | NavigationsRestApi | StorefrontAPI | Migrated | 2.3.0 | — | GET /navigations/{id} |
 | OauthApi | StorefrontAPI | Migrated | 1.4.1 | — | POST /token |
-| OmsRestApi | Extension-only StorefrontAPI | Migrated | TODO | OrdersRestApi | (extension-only) |
 | OrderAmendmentsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | CartReorderRestApi, CartsRestApi, OrdersRestApi | (extension-only) |
 | OrdersRestApi | StorefrontAPI | Migrated | 4.14.0 | — | GET /orders<br>GET /orders/{orderReference}<br>GET /orders/{orderReference}/order-items/{uuid}<br>GET /customers/{customerReference}/orders |
 | PriceProductOfferVolumesRestApi | Extension-only StorefrontAPI | Migrated | 1.1.1 | ProductOfferPricesRestApi | (extension-only) |
@@ -171,7 +168,6 @@ All StorefrontAPI and Extension-only StorefrontAPI modules. Migrated modules are
 | RelatedProductsRestApi | StorefrontAPI | Migrated | 1.5.0 | ProductsRestApi | GET /abstract-products/{id}/related-products |
 | SalesOrderThresholdsRestApi | Extension-only StorefrontAPI | Migrated | 1.1.0 | CartsRestApi, CheckoutRestApi | (extension-only) |
 | SalesReturnsRestApi | StorefrontAPI | Migrated | 1.3.0 | — | GET /return-reasons<br>GET,POST /returns<br>GET /returns/{id} |
-| SelfServicePortal | StorefrontAPI | Migrated | TODO | — | GET /booked-services<br>GET,POST /ssp-assets<br>GET /ssp-assets/{reference}<br>GET,POST /ssp-inquiries<br>GET /ssp-inquiries/{reference} |
 | SecurityBlockerRestApi | Extension-only StorefrontAPI | Migrated | 1.1.0 | — | (extension-only) |
 | ServicePointCartsRestApi | Extension-only StorefrontAPI | Migrated | 1.1.0 | CheckoutRestApi | (extension-only) |
 | ServicePointsRestApi | StorefrontAPI | Migrated | 1.2.0 | — | GET /service-points<br>GET /service-points/{id}<br>GET /service-points/{id}/service-point-addresses/{id} |
@@ -185,6 +181,16 @@ All StorefrontAPI and Extension-only StorefrontAPI modules. Migrated modules are
 | UrlsRestApi | StorefrontAPI | Migrated | 1.2.0 | — | GET /url-resolver |
 | Vertex | StorefrontAPI | Migrated | 1.2.0 | — | POST /tax-id-validate |
 | WishlistsRestApi | StorefrontAPI | Migrated | 1.8.0 | — | GET,POST /wishlists<br>GET,PATCH,DELETE /wishlists/{id}<br>POST /wishlists/{id}/wishlist-items<br>PATCH,DELETE /wishlists/{id}/wishlist-items/{id} |
+
+### Backward-compatible extension modules (no migration required)
+
+The following modules are not migrated to API Platform and do not need to be. They expose no API resource of their own — they only contribute plugins (mappers and expanders) that are consumed in a backward-compatible way by both the legacy Glue REST API and the API Platform resources of the host module they extend. Because they carry no standalone resource, they have no "Released In" version.
+
+| Module | Plugin provided | Consumed by |
+|---|---|---|
+| DiscountsRestApi | DiscountsRestQuoteRequestAttributesExpanderPlugin | QuoteRequestsRestApi |
+| MerchantRelationshipProductListsRestApi | CustomerProductListCustomerExpanderPlugin | CustomersRestApi |
+| OmsRestApi | OmsRestOrderItemsAttributesMapperPlugin | OrdersRestApi |
 
 ## Backend API modules
 

--- a/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
+++ b/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
@@ -130,60 +130,60 @@ All StorefrontAPI and Extension-only StorefrontAPI modules. Migrated modules are
 | CustomersRestApi | StorefrontAPI | Migrated | 1.28.0 | — | GET,POST /customers<br>GET,PATCH,DELETE /customers/{id}<br>GET,POST /customers/{id}/addresses<br>GET,PATCH,DELETE /customers/{id}/addresses/{id}<br>POST /customer-forgotten-password<br>PATCH /customer-restore-password/{id}<br>PATCH /customer-password/{id}<br>POST /customer-confirmation |
 | DiscountPromotionsRestApi | Extension-Only-StorefrontAPI | Migrated | 1.6.0 | CartCodesRestApi, CartsRestApi | (extension-only) |
 | DiscountsRestApi | StorefrontAPI | Migrated | TODO | — | POST /carts/{id}/vouchers<br>DELETE /carts/{id}/vouchers/{id}<br>POST /guest-carts/{id}/vouchers<br>DELETE /guest-carts/{id}/vouchers/{id} |
-| EntityTagsRestApi | Extension-only StorefrontAPI | Migrated | TODO | — | (extension-only) |
+| EntityTagsRestApi | Extension-only StorefrontAPI | Migrated | 1.1.0 | — | (extension-only) |
 | GiftCardsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | — | (extension-only) |
 | HealthCheck | StorefrontAPI | Migrated | 1.1.0 | — | GET /health-check |
 | MerchantProductOfferServicePointAvailabilitiesRestApi | Extension-only StorefrontAPI | Planned | — | ProductOfferServicePointAvailabilitiesRestApi | (extension-only) |
 | MerchantProductOfferShoppingListsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | — | (extension-only) |
 | MerchantProductOfferWishlistRestApi | Extension-only StorefrontAPI | Migrated | 1.3.0 | WishlistsRestApi | (extension-only) |
 | MerchantProductShoppingListsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | — | (extension-only) |
-| MerchantProductsRestApi | Extension-only StorefrontAPI | Migrated | TODO | CartsRestApi | (extension-only) |
+| MerchantProductsRestApi | Extension-only StorefrontAPI | Migrated | 1.1.0 | CartsRestApi | (extension-only) |
 | MerchantRelationshipProductListsRestApi | Extension-only StorefrontAPI | Migrated | TODO | CustomersRestApi | (extension-only) |
-| MerchantSalesReturnsRestApi | Extension-only StorefrontAPI | Migrated | TODO | — | (extension-only) |
-| MerchantShipmentsRestApi | Extension-only StorefrontAPI | Migrated | TODO | ShipmentsRestApi | (extension-only) |
-| MultiCartsRestApi | Extension-only StorefrontAPI | Migrated | TODO | CartsRestApi | (extension-only) |
+| MerchantSalesReturnsRestApi | Extension-only StorefrontAPI | Migrated | 1.1.0 | — | (extension-only) |
+| MerchantShipmentsRestApi | Extension-only StorefrontAPI | Migrated | 0.1.1 | ShipmentsRestApi | (extension-only) |
+| MultiCartsRestApi | Extension-only StorefrontAPI | Migrated | 1.1.0 | CartsRestApi | (extension-only) |
 | MultiFactorAuth | StorefrontAPI | Migrated | 2.5.0 | — | GET /multi-factor-auth-types, POST /multi-factor-auth-trigger, POST /multi-factor-auth-type-activate, POST /multi-factor-auth-type-verify, POST /multi-factor-auth-type-deactivate |
 | NavigationsRestApi | StorefrontAPI | Migrated | 2.3.0 | — | GET /navigations/{id} |
-| OauthApi | StorefrontAPI | Migrated | TODO | — | POST /token |
+| OauthApi | StorefrontAPI | Migrated | 1.4.1 | — | POST /token |
 | OmsRestApi | Extension-only StorefrontAPI | Migrated | TODO | OrdersRestApi | (extension-only) |
 | OrderAmendmentsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | CartReorderRestApi, CartsRestApi, OrdersRestApi | (extension-only) |
 | OrdersRestApi | StorefrontAPI | Migrated | 4.14.0 | — | GET /orders<br>GET /orders/{orderReference}<br>GET /orders/{orderReference}/order-items/{uuid}<br>GET /customers/{customerReference}/orders |
-| PriceProductOfferVolumesRestApi | Extension-only StorefrontAPI | Migrated | TODO | ProductOfferPricesRestApi | (extension-only) |
-| PriceProductVolumesRestApi | Extension-only StorefrontAPI | Migrated | TODO | ProductPricesRestApi | (extension-only) |
+| PriceProductOfferVolumesRestApi | Extension-only StorefrontAPI | Migrated | 1.1.1 | ProductOfferPricesRestApi | (extension-only) |
+| PriceProductVolumesRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | ProductPricesRestApi | (extension-only) |
 | ProductAttributesRestApi | StorefrontAPI | Migrated | 1.3.0 | — | GET /product-management-attributes<br>GET /product-management-attributes/{id} |
 | ProductBundleCartsRestApi | Extension-only StorefrontAPI | Migrated | 1.4.0 | CartsRestApi, ShipmentsRestApi | (extension-only) |
 | ProductBundlesRestApi | StorefrontAPI | Migrated | 1.2.0 | OrdersRestApi | GET /concrete-products/{id}/bundled-products |
 | ProductConfigurationShoppingListsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | ShoppingListsRestApi | (extension-only) |
 | ProductConfigurationWishlistsRestApi | Extension-only StorefrontAPI | Migrated | 1.3.0 | WishlistsRestApi | (extension-only) |
-| ProductConfigurationsPriceProductVolumesRestApi | Extension-only StorefrontAPI | Migrated | TODO | ProductConfigurationShoppingListsRestApi, ProductConfigurationWishlistsRestApi, ProductConfigurationsRestApi | (extension-only) |
+| ProductConfigurationsPriceProductVolumesRestApi | Extension-only StorefrontAPI | Migrated | 1.1.0 | ProductConfigurationShoppingListsRestApi, ProductConfigurationWishlistsRestApi, ProductConfigurationsRestApi | (extension-only) |
 | ProductConfigurationsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | CartsRestApi, OrdersRestApi, ProductsRestApi | (extension-only) |
-| ProductDiscontinuedRestApi | Extension-only StorefrontAPI | Migrated | TODO | ProductsRestApi | (extension-only) |
+| ProductDiscontinuedRestApi | Extension-only StorefrontAPI | Migrated | 1.1.1 | ProductsRestApi | (extension-only) |
 | ProductImageSetsRestApi | StorefrontAPI | Migrated | 1.3.0 | ProductsRestApi | GET /abstract-products/{id}/abstract-product-image-sets<br>GET /concrete-products/{id}/concrete-product-image-sets |
 | ProductLabelsRestApi | StorefrontAPI | Migrated | 1.5.0 | — | GET /product-labels/{id} |
 | ProductMeasurementUnitsRestApi | StorefrontAPI | Migrated | 1.3.0 | — | GET /product-measurement-units/{id}<br>GET /concrete-products/{id}/sales-units |
 | ProductOfferSalesRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | — | (extension-only) |
 | ProductOfferShoppingListsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | — | (extension-only) |
-| ProductOffersRestApi | Extension-only StorefrontAPI | Migrated | TODO | ProductsRestApi | (extension-only) |
+| ProductOffersRestApi | Extension-only StorefrontAPI | Migrated | 1.1.0 | ProductsRestApi | (extension-only) |
 | ProductOptionsRestApi | Extension-only StorefrontAPI | Migrated | 1.5.0 | CartsRestApi, OrdersRestApi, ProductsRestApi, QuoteRequestsRestApi | (extension-only) |
 | ProductReviewsRestApi | StorefrontAPI | Migrated | 1.3.0 | — | GET,POST /abstract-products/{id}/product-reviews<br>GET /abstract-products/{id}/product-reviews/{id} |
 | QuoteRequestAgentsRestApi | StorefrontAPI | Migrated | 0.4.2 | QuoteRequestsRestApi | GET,POST /agent-quote-requests<br>GET,PATCH /agent-quote-requests/{id}<br>POST /agent-quote-requests/{id}/agent-quote-request-cancel<br>POST /agent-quote-requests/{id}/agent-quote-request-revise<br>POST /agent-quote-requests/{id}/agent-quote-request-send-to-customer |
 | QuoteRequestsRestApi | StorefrontAPI | Migrated | 0.2.2 | CartsRestApi | GET,POST /quote-requests<br>GET,PATCH /quote-requests/{id}<br>POST /quote-requests/{id}/quote-request-cancel<br>POST /quote-requests/{id}/quote-request-revise<br>POST /quote-requests/{id}/quote-request-send-to-user<br>POST /quote-requests/{id}/quote-request-convert-to-quote |
 | RelatedProductsRestApi | StorefrontAPI | Migrated | 1.5.0 | ProductsRestApi | GET /abstract-products/{id}/related-products |
-| SalesOrderThresholdsRestApi | Extension-only StorefrontAPI | Migrated | TODO | CartsRestApi, CheckoutRestApi | (extension-only) |
+| SalesOrderThresholdsRestApi | Extension-only StorefrontAPI | Migrated | 1.1.0 | CartsRestApi, CheckoutRestApi | (extension-only) |
 | SalesReturnsRestApi | StorefrontAPI | Migrated | 1.3.0 | — | GET /return-reasons<br>GET,POST /returns<br>GET /returns/{id} |
 | SelfServicePortal | StorefrontAPI | Migrated | TODO | — | GET /booked-services<br>GET,POST /ssp-assets<br>GET /ssp-assets/{reference}<br>GET,POST /ssp-inquiries<br>GET /ssp-inquiries/{reference} |
-| SecurityBlockerRestApi | Extension-only StorefrontAPI | Migrated | TODO | — | (extension-only) |
-| ServicePointCartsRestApi | Extension-only StorefrontAPI | Migrated | TODO | CheckoutRestApi | (extension-only) |
+| SecurityBlockerRestApi | Extension-only StorefrontAPI | Migrated | 1.1.0 | — | (extension-only) |
+| ServicePointCartsRestApi | Extension-only StorefrontAPI | Migrated | 1.1.0 | CheckoutRestApi | (extension-only) |
 | ServicePointsRestApi | StorefrontAPI | Migrated | 1.2.0 | — | GET /service-points<br>GET /service-points/{id}<br>GET /service-points/{id}/service-point-addresses/{id} |
 | SharedCartsRestApi | StorefrontAPI | Migrated | 1.4.0 | — | POST /carts/{id}/shared-carts<br>PATCH,DELETE /shared-carts/{id} |
-| ShipmentTypeServicePointsRestApi | Extension-only StorefrontAPI | Migrated | TODO | CheckoutRestApi, ServicePointsRestApi, ShipmentTypesRestApi, ShipmentsRestApi | (extension-only) |
+| ShipmentTypeServicePointsRestApi | Extension-only StorefrontAPI | Migrated | 1.1.0 | CheckoutRestApi, ServicePointsRestApi, ShipmentTypesRestApi, ShipmentsRestApi | (extension-only) |
 | ShipmentTypesRestApi | StorefrontAPI | Migrated | 1.2.0 | — | GET /shipment-types<br>GET /shipment-types/{id} |
 | ShipmentsRestApi | Extension-only StorefrontAPI | Migrated | 1.16.0 | CheckoutRestApi, OrdersRestApi, QuoteRequestsRestApi | (extension-only) |
 | ShoppingListsRestApi | StorefrontAPI | Migrated | 1.5.0 | — | GET,POST /shopping-lists<br>GET,PATCH,DELETE /shopping-lists/{id}<br>POST /shopping-lists/{id}/shopping-list-items<br>PATCH,DELETE /shopping-lists/{id}/shopping-list-items/{id} |
 | TaxAppRestApi | StorefrontAPI | Planned | — | — | POST /tax-id-validate |
 | UpSellingProductsRestApi | StorefrontAPI | Migrated | 1.4.0 | CartsRestApi, ProductsRestApi | GET /carts/{id}/up-selling-products<br>GET /guest-carts/{id}/up-selling-products |
 | UrlsRestApi | StorefrontAPI | Migrated | 1.2.0 | — | GET /url-resolver |
-| Vertex | StorefrontAPI | Migrated | TODO | — | POST /tax-id-validate |
+| Vertex | StorefrontAPI | Migrated | 1.2.0 | — | POST /tax-id-validate |
 | WishlistsRestApi | StorefrontAPI | Migrated | 1.8.0 | — | GET,POST /wishlists<br>GET,PATCH,DELETE /wishlists/{id}<br>POST /wishlists/{id}/wishlist-items<br>PATCH,DELETE /wishlists/{id}/wishlist-items/{id} |
 
 ## Backend API modules

--- a/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
+++ b/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
@@ -132,7 +132,6 @@ All StorefrontAPI and Extension-only StorefrontAPI modules. Migrated modules are
 | EntityTagsRestApi | Extension-only StorefrontAPI | Migrated | 1.1.0 | — | (extension-only) |
 | GiftCardsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | — | (extension-only) |
 | HealthCheck | StorefrontAPI | Migrated | 1.1.0 | — | GET /health-check |
-| MerchantProductOfferServicePointAvailabilitiesRestApi | Extension-only StorefrontAPI | Planned | — | ProductOfferServicePointAvailabilitiesRestApi | (extension-only) |
 | MerchantProductOfferShoppingListsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | — | (extension-only) |
 | MerchantProductOfferWishlistRestApi | Extension-only StorefrontAPI | Migrated | 1.3.0 | WishlistsRestApi | (extension-only) |
 | MerchantProductShoppingListsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | — | (extension-only) |
@@ -176,7 +175,6 @@ All StorefrontAPI and Extension-only StorefrontAPI modules. Migrated modules are
 | ShipmentTypesRestApi | StorefrontAPI | Migrated | 1.2.0 | — | GET /shipment-types<br>GET /shipment-types/{id} |
 | ShipmentsRestApi | Extension-only StorefrontAPI | Migrated | 1.16.0 | CheckoutRestApi, OrdersRestApi, QuoteRequestsRestApi | (extension-only) |
 | ShoppingListsRestApi | StorefrontAPI | Migrated | 1.5.0 | — | GET,POST /shopping-lists<br>GET,PATCH,DELETE /shopping-lists/{id}<br>POST /shopping-lists/{id}/shopping-list-items<br>PATCH,DELETE /shopping-lists/{id}/shopping-list-items/{id} |
-| TaxAppRestApi | StorefrontAPI | Planned | — | — | POST /tax-id-validate |
 | UpSellingProductsRestApi | StorefrontAPI | Migrated | 1.4.0 | CartsRestApi, ProductsRestApi | GET /carts/{id}/up-selling-products<br>GET /guest-carts/{id}/up-selling-products |
 | UrlsRestApi | StorefrontAPI | Migrated | 1.2.0 | — | GET /url-resolver |
 | Vertex | StorefrontAPI | Migrated | 1.2.0 | — | POST /tax-id-validate |

--- a/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
+++ b/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
@@ -1,7 +1,7 @@
 ---
 title: Migration status - Glue API to API Platform
 description: Tracks the migration status of API modules to the Spryker API Platform across StorefrontAPI and BackendAPI, with endpoint coverage and a high-level migration workflow.
-last_updated: Jun 5, 2026
+last_updated: Jun 9, 2026
 template: howto-guide-template
 redirect_from:
   - /docs/dg/dev/upgrade-and-migrate/glue-api-migration-status.html
@@ -86,130 +86,130 @@ The previous API stack and API Platform run **side by side** during the transiti
 
 All StorefrontAPI and Extension-only StorefrontAPI modules. Migrated modules are listed first.
 
-| Module | Category | Status | Requires | Key endpoints |
-|---|---|---|---|---|
-| ContentProductAbstractListsRestApi | StorefrontAPI | Migrated | ProductsRestApi | GET /content-product-abstract-lists/{id}<br>GET /content-product-abstract-lists/{id}/abstract-products |
-| MerchantOpeningHoursRestApi | StorefrontAPI | Migrated | — | GET /merchants/{id}/merchant-opening-hours |
-| MerchantCategoriesRestApi | Extension-only StorefrontAPI | Migrated | MerchantsRestApi | (extension-only) |
-| MerchantProductOffersRestApi | StorefrontAPI | Migrated | — | GET /concrete-products/{id}/product-offers<br>GET /product-offers/{id} |
-| MerchantProductOfferServicePointAvailabilitiesRestApi | Extension-only StorefrontAPI | Migrated | ProductOfferServicePointAvailabilitiesRestApi | (extension-only) |
-| MerchantsRestApi | StorefrontAPI | Migrated | — | GET /merchants<br>GET /merchants/{id}<br>GET /merchants/{id}/merchant-addresses |
-| OrderPaymentsRestApi | StorefrontAPI | Migrated | — | POST /order-payments |
-| PaymentsRestApi | StorefrontAPI | Migrated | — | POST /payments<br>POST /payment-cancellations<br>POST /payment-customers |
-| ProductAvailabilitiesRestApi | StorefrontAPI | Migrated | ProductsRestApi | GET /abstract-products/{id}/abstract-product-availabilities<br>GET /concrete-products/{id}/concrete-product-availabilities |
-| ProductOfferAvailabilitiesRestApi | StorefrontAPI | Migrated | — | GET /product-offers/{id}/product-offer-availabilities |
-| ProductOfferServicePointAvailabilitiesRestApi | StorefrontAPI | Migrated | — | POST /product-offer-service-point-availabilities |
-| ProductOfferPricesRestApi | StorefrontAPI | Migrated | — | GET /product-offers/{id}/product-offer-prices |
-| ProductPricesRestApi | StorefrontAPI | Migrated | ProductsRestApi | GET /abstract-products/{id}/abstract-product-prices<br>GET /concrete-products/{id}/concrete-product-prices |
-| ProductTaxSetsRestApi | StorefrontAPI | Migrated | — | GET /abstract-products/{id}/product-tax-sets |
-| ProductsRestApi | StorefrontAPI | Migrated | — | GET /abstract-products/{id}<br>GET /concrete-products/{id} |
-| ShipmentTypeProductOfferServicePointAvailabilitiesRestApi | Extension-only StorefrontAPI | Migrated | ProductOfferServicePointAvailabilitiesRestApi | (extension-only) |
-| StoresApi | StorefrontAPI | Migrated | — | GET /stores |
-| AgentAuthRestApi | StorefrontAPI | Migrated | — | POST /agent-access-tokens<br>POST /agent-customer-impersonation-access-tokens<br>GET /agent-customer-search |
-| AlternativeProductsRestApi | StorefrontAPI | Migrated | ProductsRestApi | GET /abstract-products/{id}/related-products<br>GET /concrete-products/{id}/abstract-alternative-products<br>GET /concrete-products/{id}/concrete-alternative-products |
-| AuthRestApi | StorefrontAPI | Migrated | — | POST /token<br>POST /access-tokens<br>POST /refresh-tokens<br>DELETE /refresh-tokens/{id} |
-| AvailabilityNotificationsRestApi | StorefrontAPI | Migrated | — | POST /availability-notifications<br>DELETE /availability-notifications/{id}<br>GET /my-availability-notifications<br>GET /customers/{id}/availability-notifications |
-| CartCodesRestApi | StorefrontAPI | Migrated | CartsRestApi | POST /carts/{id}/cart-codes<br>DELETE /carts/{id}/cart-codes/{id}<br>POST /guest-carts/{id}/cart-codes<br>DELETE /guest-carts/{id}/cart-codes/{id} |
-| CartPermissionGroupsRestApi | StorefrontAPI | Migrated | — | GET /cart-permission-groups<br>GET /cart-permission-groups/{id} |
-| CartReorderRestApi | StorefrontAPI | Migrated | CartsRestApi | POST /cart-reorder |
-| CartsRestApi | StorefrontAPI | Migrated | — | GET,POST /carts<br>GET,PATCH,DELETE /carts/{id}<br>POST /carts/{id}/items<br>PATCH,DELETE /carts/{id}/items/{id}<br>GET /guest-carts<br>GET,PATCH /guest-carts/{id}<br>POST /guest-carts/{id}/guest-cart-items<br>PATCH,DELETE /guest-carts/{id}/guest-cart-items/{id}<br>GET /customers/{id}/carts |
-| CatalogSearchRestApi | StorefrontAPI | Migrated | — | GET /catalog-search<br>GET /catalog-search-suggestions |
-| CategoriesRestApi | StorefrontAPI | Migrated | — | GET /category-trees<br>GET /category-nodes/{id} |
-| CheckoutRestApi | StorefrontAPI | Migrated | CartsRestApi | POST /checkout-data<br>POST /checkout |
-| CmsPagesRestApi | StorefrontAPI | Migrated | — | GET /cms-pages<br>GET /cms-pages/{id} |
-| CompaniesRestApi | StorefrontAPI | Migrated | — | GET /companies<br>GET /companies/{id} |
-| CompanyBusinessUnitAddressesRestApi | StorefrontAPI | Migrated | — | GET /company-business-unit-addresses<br>GET /company-business-unit-addresses/{id} |
-| CompanyBusinessUnitsRestApi | StorefrontAPI | Migrated | — | GET /company-business-units<br>GET /company-business-units/{id} |
-| CompanyRolesRestApi | StorefrontAPI | Migrated | — | GET /company-roles<br>GET /company-roles/{id} |
-| CompanyUserAuthRestApi | StorefrontAPI | Migrated | — | POST /company-user-access-tokens |
-| CompanyUsersRestApi | StorefrontAPI | Migrated | — | GET /company-users<br>GET /company-users/{id} |
-| ConfigurableBundleCartsRestApi | StorefrontAPI | Migrated | CartsRestApi | POST /carts/{id}/configured-bundles<br>PATCH,DELETE /carts/{id}/configured-bundles/{id}<br>POST,PATCH,DELETE /guest-carts/{id}/guest-configured-bundles/{id} |
-| ConfigurableBundlesRestApi | StorefrontAPI | Migrated | — | GET /configurable-bundle-templates<br>GET /configurable-bundle-templates/{id} |
-| ContentBannersRestApi | StorefrontAPI | Migrated | — | GET /content-banners/{id} |
-| CustomerAccessRestApi | StorefrontAPI | Migrated | — | GET /customer-access |
-| CustomersRestApi | StorefrontAPI | Migrated | — | GET,POST /customers<br>GET,PATCH,DELETE /customers/{id}<br>GET,POST /customers/{id}/addresses<br>GET,PATCH,DELETE /customers/{id}/addresses/{id}<br>POST /customer-forgotten-password<br>PATCH /customer-restore-password/{id}<br>PATCH /customer-password/{id}<br>POST /customer-confirmation |
-| DiscountPromotionsRestApi | Extension-Only-StorefrontAPI | Migrated | CartCodesRestApi, CartsRestApi | (extension-only) |
-| DiscountsRestApi | StorefrontAPI | Migrated | — | POST /carts/{id}/vouchers<br>DELETE /carts/{id}/vouchers/{id}<br>POST /guest-carts/{id}/vouchers<br>DELETE /guest-carts/{id}/vouchers/{id} |
-| EntityTagsRestApi | Extension-only StorefrontAPI | Migrated | — | (extension-only) |
-| GiftCardsRestApi | Extension-only StorefrontAPI | Migrated | — | (extension-only) |
-| HealthCheck | StorefrontAPI | Migrated | — | GET /health-check |
-| MerchantProductOfferServicePointAvailabilitiesRestApi | Extension-only StorefrontAPI | Planned | ProductOfferServicePointAvailabilitiesRestApi | (extension-only) |
-| MerchantProductOfferShoppingListsRestApi | Extension-only StorefrontAPI | Migrated | — | (extension-only) |
-| MerchantProductOfferWishlistRestApi | Extension-only StorefrontAPI | Migrated | WishlistsRestApi | (extension-only) |
-| MerchantProductShoppingListsRestApi | Extension-only StorefrontAPI | Migrated | — | (extension-only) |
-| MerchantProductsRestApi | Extension-only StorefrontAPI | Migrated | CartsRestApi | (extension-only) |
-| MerchantRelationshipProductListsRestApi | Extension-only StorefrontAPI | Migrated | CustomersRestApi | (extension-only) |
-| MerchantSalesReturnsRestApi | Extension-only StorefrontAPI | Migrated | — | (extension-only) |
-| MerchantShipmentsRestApi | Extension-only StorefrontAPI | Migrated | ShipmentsRestApi | (extension-only) |
-| MultiCartsRestApi | Extension-only StorefrontAPI | Migrated | CartsRestApi | (extension-only) |
-| MultiFactorAuth | StorefrontAPI | Migrated | — | GET /multi-factor-auth-types, POST /multi-factor-auth-trigger, POST /multi-factor-auth-type-activate, POST /multi-factor-auth-type-verify, POST /multi-factor-auth-type-deactivate |
-| NavigationsRestApi | StorefrontAPI | Migrated | — | GET /navigations/{id} |
-| OauthApi | StorefrontAPI | Migrated | — | POST /token |
-| OmsRestApi | Extension-only StorefrontAPI | Migrated | OrdersRestApi | (extension-only) |
-| OrderAmendmentsRestApi | Extension-only StorefrontAPI | Migrated | CartReorderRestApi, CartsRestApi, OrdersRestApi | (extension-only) |
-| OrdersRestApi | StorefrontAPI | Migrated | — | GET /orders<br>GET /orders/{orderReference}<br>GET /orders/{orderReference}/order-items/{uuid}<br>GET /customers/{customerReference}/orders |
-| PriceProductOfferVolumesRestApi | Extension-only StorefrontAPI | Migrated | ProductOfferPricesRestApi | (extension-only) |
-| PriceProductVolumesRestApi | Extension-only StorefrontAPI | Migrated | ProductPricesRestApi | (extension-only) |
-| ProductAttributesRestApi | StorefrontAPI | Migrated | — | GET /product-management-attributes<br>GET /product-management-attributes/{id} |
-| ProductBundleCartsRestApi | Extension-only StorefrontAPI | Migrated | CartsRestApi, ShipmentsRestApi | (extension-only) |
-| ProductBundlesRestApi | StorefrontAPI | Migrated | OrdersRestApi | GET /concrete-products/{id}/bundled-products |
-| ProductConfigurationShoppingListsRestApi | Extension-only StorefrontAPI | Migrated | ShoppingListsRestApi | (extension-only) |
-| ProductConfigurationWishlistsRestApi | Extension-only StorefrontAPI | Migrated | WishlistsRestApi | (extension-only) |
-| ProductConfigurationsPriceProductVolumesRestApi | Extension-only StorefrontAPI | Migrated | ProductConfigurationShoppingListsRestApi, ProductConfigurationWishlistsRestApi, ProductConfigurationsRestApi | (extension-only) |
-| ProductConfigurationsRestApi | Extension-only StorefrontAPI | Migrated | CartsRestApi, OrdersRestApi, ProductsRestApi | (extension-only) |
-| ProductDiscontinuedRestApi | Extension-only StorefrontAPI | Migrated | ProductsRestApi | (extension-only) |
-| ProductImageSetsRestApi | StorefrontAPI | Migrated | ProductsRestApi | GET /abstract-products/{id}/abstract-product-image-sets<br>GET /concrete-products/{id}/concrete-product-image-sets |
-| ProductLabelsRestApi | StorefrontAPI | Migrated | — | GET /product-labels/{id} |
-| ProductMeasurementUnitsRestApi | StorefrontAPI | Migrated | — | GET /product-measurement-units/{id}<br>GET /concrete-products/{id}/sales-units |
-| ProductOfferSalesRestApi | Extension-only StorefrontAPI | Migrated | — | (extension-only) |
-| ProductOfferShoppingListsRestApi | Extension-only StorefrontAPI | Migrated | — | (extension-only) |
-| ProductOffersRestApi | Extension-only StorefrontAPI | Migrated | ProductsRestApi | (extension-only) |
-| ProductOptionsRestApi | Extension-only StorefrontAPI | Migrated | CartsRestApi, OrdersRestApi, ProductsRestApi, QuoteRequestsRestApi | (extension-only) |
-| ProductReviewsRestApi | StorefrontAPI | Migrated | — | GET,POST /abstract-products/{id}/product-reviews<br>GET /abstract-products/{id}/product-reviews/{id} |
-| QuoteRequestAgentsRestApi | StorefrontAPI | Migrated | QuoteRequestsRestApi | GET,POST /agent-quote-requests<br>GET,PATCH /agent-quote-requests/{id}<br>POST /agent-quote-requests/{id}/agent-quote-request-cancel<br>POST /agent-quote-requests/{id}/agent-quote-request-revise<br>POST /agent-quote-requests/{id}/agent-quote-request-send-to-customer |
-| QuoteRequestsRestApi | StorefrontAPI | Migrated | CartsRestApi | GET,POST /quote-requests<br>GET,PATCH /quote-requests/{id}<br>POST /quote-requests/{id}/quote-request-cancel<br>POST /quote-requests/{id}/quote-request-revise<br>POST /quote-requests/{id}/quote-request-send-to-user<br>POST /quote-requests/{id}/quote-request-convert-to-quote |
-| RelatedProductsRestApi | StorefrontAPI | Migrated | ProductsRestApi | GET /abstract-products/{id}/related-products |
-| SalesOrderThresholdsRestApi | Extension-only StorefrontAPI | Migrated | CartsRestApi, CheckoutRestApi | (extension-only) |
-| SalesReturnsRestApi | StorefrontAPI | Migrated | — | GET /return-reasons<br>GET,POST /returns<br>GET /returns/{id} |
-| SelfServicePortal | StorefrontAPI | Migrated | — | GET /booked-services<br>GET,POST /ssp-assets<br>GET /ssp-assets/{reference}<br>GET,POST /ssp-inquiries<br>GET /ssp-inquiries/{reference} |
-| SecurityBlockerRestApi | Extension-only StorefrontAPI | Migrated | — | (extension-only) |
-| ServicePointCartsRestApi | Extension-only StorefrontAPI | Migrated | CheckoutRestApi | (extension-only) |
-| ServicePointsRestApi | StorefrontAPI | Migrated | — | GET /service-points<br>GET /service-points/{id}<br>GET /service-points/{id}/service-point-addresses/{id} |
-| SharedCartsRestApi | StorefrontAPI | Migrated | — | POST /carts/{id}/shared-carts<br>PATCH,DELETE /shared-carts/{id} |
-| ShipmentTypeServicePointsRestApi | Extension-only StorefrontAPI | Migrated | CheckoutRestApi, ServicePointsRestApi, ShipmentTypesRestApi, ShipmentsRestApi | (extension-only) |
-| ShipmentTypesRestApi | StorefrontAPI | Migrated | — | GET /shipment-types<br>GET /shipment-types/{id} |
-| ShipmentsRestApi | Extension-only StorefrontAPI | Migrated | CheckoutRestApi, OrdersRestApi, QuoteRequestsRestApi | (extension-only) |
-| ShoppingListsRestApi | StorefrontAPI | Migrated | — | GET,POST /shopping-lists<br>GET,PATCH,DELETE /shopping-lists/{id}<br>POST /shopping-lists/{id}/shopping-list-items<br>PATCH,DELETE /shopping-lists/{id}/shopping-list-items/{id} |
-| TaxAppRestApi | StorefrontAPI | Planned | — | POST /tax-id-validate |
-| UpSellingProductsRestApi | StorefrontAPI | Migrated | CartsRestApi, ProductsRestApi | GET /carts/{id}/up-selling-products<br>GET /guest-carts/{id}/up-selling-products |
-| UrlsRestApi | StorefrontAPI | Migrated | — | GET /url-resolver |
-| Vertex | StorefrontAPI | Migrated | — | POST /tax-id-validate |
-| WishlistsRestApi | StorefrontAPI | Migrated | — | GET,POST /wishlists<br>GET,PATCH,DELETE /wishlists/{id}<br>POST /wishlists/{id}/wishlist-items<br>PATCH,DELETE /wishlists/{id}/wishlist-items/{id} |
+| Module | Category | Status | Released In | Requires | Key endpoints |
+|---|---|---|---|---|---|
+| ContentProductAbstractListsRestApi | StorefrontAPI | Migrated | 1.4.0 | ProductsRestApi | GET /content-product-abstract-lists/{id}<br>GET /content-product-abstract-lists/{id}/abstract-products |
+| MerchantOpeningHoursRestApi | StorefrontAPI | Migrated | 1.2.0 | — | GET /merchants/{id}/merchant-opening-hours |
+| MerchantCategoriesRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | MerchantsRestApi | (extension-only) |
+| MerchantProductOffersRestApi | StorefrontAPI | Migrated | 2.2.0 | — | GET /concrete-products/{id}/product-offers<br>GET /product-offers/{id} |
+| MerchantProductOfferServicePointAvailabilitiesRestApi | Extension-only StorefrontAPI | Migrated | 0.4.0 | ProductOfferServicePointAvailabilitiesRestApi | (extension-only) |
+| MerchantsRestApi | StorefrontAPI | Migrated | 1.2.0 | — | GET /merchants<br>GET /merchants/{id}<br>GET /merchants/{id}/merchant-addresses |
+| OrderPaymentsRestApi | StorefrontAPI | Migrated | 1.2.0 | — | POST /order-payments |
+| PaymentsRestApi | StorefrontAPI | Migrated | 1.7.0 | — | POST /payments<br>POST /payment-cancellations<br>POST /payment-customers |
+| ProductAvailabilitiesRestApi | StorefrontAPI | Migrated | 4.4.0 | ProductsRestApi | GET /abstract-products/{id}/abstract-product-availabilities<br>GET /concrete-products/{id}/concrete-product-availabilities |
+| ProductOfferAvailabilitiesRestApi | StorefrontAPI | Migrated | 1.3.0 | — | GET /product-offers/{id}/product-offer-availabilities |
+| ProductOfferServicePointAvailabilitiesRestApi | StorefrontAPI | Migrated | 1.2.0 | — | POST /product-offer-service-point-availabilities |
+| ProductOfferPricesRestApi | StorefrontAPI | Migrated | 2.5.0 | — | GET /product-offers/{id}/product-offer-prices |
+| ProductPricesRestApi | StorefrontAPI | Migrated | 1.12.0 | ProductsRestApi | GET /abstract-products/{id}/abstract-product-prices<br>GET /concrete-products/{id}/concrete-product-prices |
+| ProductTaxSetsRestApi | StorefrontAPI | Migrated | 2.3.0 | — | GET /abstract-products/{id}/product-tax-sets |
+| ProductsRestApi | StorefrontAPI | Migrated | 2.17.0 | — | GET /abstract-products/{id}<br>GET /concrete-products/{id} |
+| ShipmentTypeProductOfferServicePointAvailabilitiesRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | ProductOfferServicePointAvailabilitiesRestApi | (extension-only) |
+| StoresApi | StorefrontAPI | Migrated | 1.3.0 | — | GET /stores |
+| AgentAuthRestApi | StorefrontAPI | Migrated | 1.3.0 | — | POST /agent-access-tokens<br>POST /agent-customer-impersonation-access-tokens<br>GET /agent-customer-search |
+| AlternativeProductsRestApi | StorefrontAPI | Migrated | 1.3.0 | ProductsRestApi | GET /abstract-products/{id}/related-products<br>GET /concrete-products/{id}/abstract-alternative-products<br>GET /concrete-products/{id}/concrete-alternative-products |
+| AuthRestApi | StorefrontAPI | Migrated | 2.17.0 | — | POST /token<br>POST /access-tokens<br>POST /refresh-tokens<br>DELETE /refresh-tokens/{id} |
+| AvailabilityNotificationsRestApi | StorefrontAPI | Migrated | 1.4.0 | — | POST /availability-notifications<br>DELETE /availability-notifications/{id}<br>GET /my-availability-notifications<br>GET /customers/{id}/availability-notifications |
+| CartCodesRestApi | StorefrontAPI | Migrated | 1.7.0 | CartsRestApi | POST /carts/{id}/cart-codes<br>DELETE /carts/{id}/cart-codes/{id}<br>POST /guest-carts/{id}/cart-codes<br>DELETE /guest-carts/{id}/cart-codes/{id} |
+| CartPermissionGroupsRestApi | StorefrontAPI | Migrated | 1.4.0 | — | GET /cart-permission-groups<br>GET /cart-permission-groups/{id} |
+| CartReorderRestApi | StorefrontAPI | Migrated | 1.3.0 | CartsRestApi | POST /cart-reorder |
+| CartsRestApi | StorefrontAPI | Migrated | 5.25.0 | — | GET,POST /carts<br>GET,PATCH,DELETE /carts/{id}<br>POST /carts/{id}/items<br>PATCH,DELETE /carts/{id}/items/{id}<br>GET /guest-carts<br>GET,PATCH /guest-carts/{id}<br>POST /guest-carts/{id}/guest-cart-items<br>PATCH,DELETE /guest-carts/{id}/guest-cart-items/{id}<br>GET /customers/{id}/carts |
+| CatalogSearchRestApi | StorefrontAPI | Migrated | 2.13.0 | — | GET /catalog-search<br>GET /catalog-search-suggestions |
+| CategoriesRestApi | StorefrontAPI | Migrated | 1.9.0 | — | GET /category-trees<br>GET /category-nodes/{id} |
+| CheckoutRestApi | StorefrontAPI | Migrated | 3.14.0 | CartsRestApi | POST /checkout-data<br>POST /checkout |
+| CmsPagesRestApi | StorefrontAPI | Migrated | 1.2.0 | — | GET /cms-pages<br>GET /cms-pages/{id} |
+| CompaniesRestApi | StorefrontAPI | Migrated | 1.5.0 | — | GET /companies<br>GET /companies/{id} |
+| CompanyBusinessUnitAddressesRestApi | StorefrontAPI | Migrated | 1.4.0 | — | GET /company-business-unit-addresses<br>GET /company-business-unit-addresses/{id} |
+| CompanyBusinessUnitsRestApi | StorefrontAPI | Migrated | 1.6.0 | — | GET /company-business-units<br>GET /company-business-units/{id} |
+| CompanyRolesRestApi | StorefrontAPI | Migrated | 1.3.0 | — | GET /company-roles<br>GET /company-roles/{id} |
+| CompanyUserAuthRestApi | StorefrontAPI | Migrated | 2.3.0 | — | POST /company-user-access-tokens |
+| CompanyUsersRestApi | StorefrontAPI | Migrated | 2.11.0 | — | GET /company-users<br>GET /company-users/{id} |
+| ConfigurableBundleCartsRestApi | StorefrontAPI | Migrated | 1.2.0 | CartsRestApi | POST /carts/{id}/configured-bundles<br>PATCH,DELETE /carts/{id}/configured-bundles/{id}<br>POST,PATCH,DELETE /guest-carts/{id}/guest-configured-bundles/{id} |
+| ConfigurableBundlesRestApi | StorefrontAPI | Migrated | 1.3.0 | — | GET /configurable-bundle-templates<br>GET /configurable-bundle-templates/{id} |
+| ContentBannersRestApi | StorefrontAPI | Migrated | 2.4.0 | — | GET /content-banners/{id} |
+| CustomerAccessRestApi | StorefrontAPI | Migrated | 1.3.0 | — | GET /customer-access |
+| CustomersRestApi | StorefrontAPI | Migrated | 1.28.0 | — | GET,POST /customers<br>GET,PATCH,DELETE /customers/{id}<br>GET,POST /customers/{id}/addresses<br>GET,PATCH,DELETE /customers/{id}/addresses/{id}<br>POST /customer-forgotten-password<br>PATCH /customer-restore-password/{id}<br>PATCH /customer-password/{id}<br>POST /customer-confirmation |
+| DiscountPromotionsRestApi | Extension-Only-StorefrontAPI | Migrated | 1.6.0 | CartCodesRestApi, CartsRestApi | (extension-only) |
+| DiscountsRestApi | StorefrontAPI | Migrated | TODO | — | POST /carts/{id}/vouchers<br>DELETE /carts/{id}/vouchers/{id}<br>POST /guest-carts/{id}/vouchers<br>DELETE /guest-carts/{id}/vouchers/{id} |
+| EntityTagsRestApi | Extension-only StorefrontAPI | Migrated | TODO | — | (extension-only) |
+| GiftCardsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | — | (extension-only) |
+| HealthCheck | StorefrontAPI | Migrated | 1.1.0 | — | GET /health-check |
+| MerchantProductOfferServicePointAvailabilitiesRestApi | Extension-only StorefrontAPI | Planned | — | ProductOfferServicePointAvailabilitiesRestApi | (extension-only) |
+| MerchantProductOfferShoppingListsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | — | (extension-only) |
+| MerchantProductOfferWishlistRestApi | Extension-only StorefrontAPI | Migrated | 1.3.0 | WishlistsRestApi | (extension-only) |
+| MerchantProductShoppingListsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | — | (extension-only) |
+| MerchantProductsRestApi | Extension-only StorefrontAPI | Migrated | TODO | CartsRestApi | (extension-only) |
+| MerchantRelationshipProductListsRestApi | Extension-only StorefrontAPI | Migrated | TODO | CustomersRestApi | (extension-only) |
+| MerchantSalesReturnsRestApi | Extension-only StorefrontAPI | Migrated | TODO | — | (extension-only) |
+| MerchantShipmentsRestApi | Extension-only StorefrontAPI | Migrated | TODO | ShipmentsRestApi | (extension-only) |
+| MultiCartsRestApi | Extension-only StorefrontAPI | Migrated | TODO | CartsRestApi | (extension-only) |
+| MultiFactorAuth | StorefrontAPI | Migrated | 2.5.0 | — | GET /multi-factor-auth-types, POST /multi-factor-auth-trigger, POST /multi-factor-auth-type-activate, POST /multi-factor-auth-type-verify, POST /multi-factor-auth-type-deactivate |
+| NavigationsRestApi | StorefrontAPI | Migrated | 2.3.0 | — | GET /navigations/{id} |
+| OauthApi | StorefrontAPI | Migrated | TODO | — | POST /token |
+| OmsRestApi | Extension-only StorefrontAPI | Migrated | TODO | OrdersRestApi | (extension-only) |
+| OrderAmendmentsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | CartReorderRestApi, CartsRestApi, OrdersRestApi | (extension-only) |
+| OrdersRestApi | StorefrontAPI | Migrated | 4.14.0 | — | GET /orders<br>GET /orders/{orderReference}<br>GET /orders/{orderReference}/order-items/{uuid}<br>GET /customers/{customerReference}/orders |
+| PriceProductOfferVolumesRestApi | Extension-only StorefrontAPI | Migrated | TODO | ProductOfferPricesRestApi | (extension-only) |
+| PriceProductVolumesRestApi | Extension-only StorefrontAPI | Migrated | TODO | ProductPricesRestApi | (extension-only) |
+| ProductAttributesRestApi | StorefrontAPI | Migrated | 1.3.0 | — | GET /product-management-attributes<br>GET /product-management-attributes/{id} |
+| ProductBundleCartsRestApi | Extension-only StorefrontAPI | Migrated | 1.4.0 | CartsRestApi, ShipmentsRestApi | (extension-only) |
+| ProductBundlesRestApi | StorefrontAPI | Migrated | 1.2.0 | OrdersRestApi | GET /concrete-products/{id}/bundled-products |
+| ProductConfigurationShoppingListsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | ShoppingListsRestApi | (extension-only) |
+| ProductConfigurationWishlistsRestApi | Extension-only StorefrontAPI | Migrated | 1.3.0 | WishlistsRestApi | (extension-only) |
+| ProductConfigurationsPriceProductVolumesRestApi | Extension-only StorefrontAPI | Migrated | TODO | ProductConfigurationShoppingListsRestApi, ProductConfigurationWishlistsRestApi, ProductConfigurationsRestApi | (extension-only) |
+| ProductConfigurationsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | CartsRestApi, OrdersRestApi, ProductsRestApi | (extension-only) |
+| ProductDiscontinuedRestApi | Extension-only StorefrontAPI | Migrated | TODO | ProductsRestApi | (extension-only) |
+| ProductImageSetsRestApi | StorefrontAPI | Migrated | 1.3.0 | ProductsRestApi | GET /abstract-products/{id}/abstract-product-image-sets<br>GET /concrete-products/{id}/concrete-product-image-sets |
+| ProductLabelsRestApi | StorefrontAPI | Migrated | 1.5.0 | — | GET /product-labels/{id} |
+| ProductMeasurementUnitsRestApi | StorefrontAPI | Migrated | 1.3.0 | — | GET /product-measurement-units/{id}<br>GET /concrete-products/{id}/sales-units |
+| ProductOfferSalesRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | — | (extension-only) |
+| ProductOfferShoppingListsRestApi | Extension-only StorefrontAPI | Migrated | 1.2.0 | — | (extension-only) |
+| ProductOffersRestApi | Extension-only StorefrontAPI | Migrated | TODO | ProductsRestApi | (extension-only) |
+| ProductOptionsRestApi | Extension-only StorefrontAPI | Migrated | 1.5.0 | CartsRestApi, OrdersRestApi, ProductsRestApi, QuoteRequestsRestApi | (extension-only) |
+| ProductReviewsRestApi | StorefrontAPI | Migrated | 1.3.0 | — | GET,POST /abstract-products/{id}/product-reviews<br>GET /abstract-products/{id}/product-reviews/{id} |
+| QuoteRequestAgentsRestApi | StorefrontAPI | Migrated | 0.4.2 | QuoteRequestsRestApi | GET,POST /agent-quote-requests<br>GET,PATCH /agent-quote-requests/{id}<br>POST /agent-quote-requests/{id}/agent-quote-request-cancel<br>POST /agent-quote-requests/{id}/agent-quote-request-revise<br>POST /agent-quote-requests/{id}/agent-quote-request-send-to-customer |
+| QuoteRequestsRestApi | StorefrontAPI | Migrated | 0.2.2 | CartsRestApi | GET,POST /quote-requests<br>GET,PATCH /quote-requests/{id}<br>POST /quote-requests/{id}/quote-request-cancel<br>POST /quote-requests/{id}/quote-request-revise<br>POST /quote-requests/{id}/quote-request-send-to-user<br>POST /quote-requests/{id}/quote-request-convert-to-quote |
+| RelatedProductsRestApi | StorefrontAPI | Migrated | 1.5.0 | ProductsRestApi | GET /abstract-products/{id}/related-products |
+| SalesOrderThresholdsRestApi | Extension-only StorefrontAPI | Migrated | TODO | CartsRestApi, CheckoutRestApi | (extension-only) |
+| SalesReturnsRestApi | StorefrontAPI | Migrated | 1.3.0 | — | GET /return-reasons<br>GET,POST /returns<br>GET /returns/{id} |
+| SelfServicePortal | StorefrontAPI | Migrated | TODO | — | GET /booked-services<br>GET,POST /ssp-assets<br>GET /ssp-assets/{reference}<br>GET,POST /ssp-inquiries<br>GET /ssp-inquiries/{reference} |
+| SecurityBlockerRestApi | Extension-only StorefrontAPI | Migrated | TODO | — | (extension-only) |
+| ServicePointCartsRestApi | Extension-only StorefrontAPI | Migrated | TODO | CheckoutRestApi | (extension-only) |
+| ServicePointsRestApi | StorefrontAPI | Migrated | 1.2.0 | — | GET /service-points<br>GET /service-points/{id}<br>GET /service-points/{id}/service-point-addresses/{id} |
+| SharedCartsRestApi | StorefrontAPI | Migrated | 1.4.0 | — | POST /carts/{id}/shared-carts<br>PATCH,DELETE /shared-carts/{id} |
+| ShipmentTypeServicePointsRestApi | Extension-only StorefrontAPI | Migrated | TODO | CheckoutRestApi, ServicePointsRestApi, ShipmentTypesRestApi, ShipmentsRestApi | (extension-only) |
+| ShipmentTypesRestApi | StorefrontAPI | Migrated | 1.2.0 | — | GET /shipment-types<br>GET /shipment-types/{id} |
+| ShipmentsRestApi | Extension-only StorefrontAPI | Migrated | 1.16.0 | CheckoutRestApi, OrdersRestApi, QuoteRequestsRestApi | (extension-only) |
+| ShoppingListsRestApi | StorefrontAPI | Migrated | 1.5.0 | — | GET,POST /shopping-lists<br>GET,PATCH,DELETE /shopping-lists/{id}<br>POST /shopping-lists/{id}/shopping-list-items<br>PATCH,DELETE /shopping-lists/{id}/shopping-list-items/{id} |
+| TaxAppRestApi | StorefrontAPI | Planned | — | — | POST /tax-id-validate |
+| UpSellingProductsRestApi | StorefrontAPI | Migrated | 1.4.0 | CartsRestApi, ProductsRestApi | GET /carts/{id}/up-selling-products<br>GET /guest-carts/{id}/up-selling-products |
+| UrlsRestApi | StorefrontAPI | Migrated | 1.2.0 | — | GET /url-resolver |
+| Vertex | StorefrontAPI | Migrated | TODO | — | POST /tax-id-validate |
+| WishlistsRestApi | StorefrontAPI | Migrated | 1.8.0 | — | GET,POST /wishlists<br>GET,PATCH,DELETE /wishlists/{id}<br>POST /wishlists/{id}/wishlist-items<br>PATCH,DELETE /wishlists/{id}/wishlist-items/{id} |
 
 ## Backend API modules
 
 All BackendAPI modules tracked in the migration scope.
 
-| Module | Category | Status | Requires | Key endpoints |
-|---|---|---|---|---|
-| CartNotesBackendApi | Extension-Only BackendAPI | Planned | SalesOrdersBackendApi | (extension-only) |
-| CategoriesBackendApi | BackendAPI | Planned | — | GET,POST /categories<br>GET,PATCH /categories/{id} |
-| DynamicEntityBackendApi | BackendAPI | Planned | — | GET,POST,PATCH,PUT /dynamic-entity/{entity-name} (~62 auto-generated entity endpoints) |
-| OauthBackendApi | BackendAPI | Planned | — | POST /token |
-| PickingListsBackendApi | BackendAPI | Planned | — | GET /picking-lists<br>GET /picking-lists/{id}<br>PATCH /picking-lists/{id}/picking-list-items/{id}<br>POST /start-picking |
-| PickingListsUsersBackendApi | Extension-Only BackendAPI | Planned | PickingListsBackendApi, UsersBackendApi | (extension-only) |
-| PickingListsWarehousesBackendApi | Extension-Only BackendAPI | Planned | PickingListsBackendApi, WarehousesBackendApi | (extension-only) |
-| ProductAttributesBackendApi | BackendAPI | Planned | — | GET,POST /product-attributes<br>GET,PATCH /product-attributes/{id} |
-| ProductImageSetsBackendApi | BackendAPI | Planned | — | GET /concrete-product-image-sets |
-| ProductPackagingUnitsBackendApi | Extension-Only BackendAPI | Planned | PickingListsBackendApi | (extension-only) |
-| ProductsBackendApi | BackendAPI | Planned | — | GET,POST /product-abstract<br>DELETE,GET,PATCH /product-abstract/{id} |
-| PushNotificationsBackendApi | BackendAPI | Planned | — | GET,POST /push-notification-providers<br>PATCH,DELETE /push-notification-providers/{id}<br>POST /push-notification-subscriptions |
-| SalesOrdersBackendApi | BackendAPI | Planned | — | GET /sales-orders |
-| ServicePointsBackendApi | BackendAPI | Planned | — | GET,POST /service-points<br>GET,PATCH /service-points/{id}<br>GET,POST /service-point-addresses<br>PATCH /service-points/{id}/service-point-addresses/{id}<br>GET,POST /service-types<br>GET,PATCH /service-types/{id}<br>GET,POST /services<br>GET,PATCH /services/{id} |
-| ShipmentTypesBackendApi | BackendAPI | Planned | — | GET,POST /shipment-types<br>GET,PATCH /shipment-types/{id} |
-| ShipmentsBackendApi | BackendAPI | Planned | — | GET /sales-shipments |
-| StoresBackendApi | BackendAPI | Planned | — | GET,POST,PATCH /stores |
-| UsersBackendApi | BackendAPI | Planned | — | GET /users |
-| WarehouseOauthBackendApi | BackendAPI | Planned | — | POST /warehouse-tokens |
-| WarehouseUsersBackendApi | BackendAPI | Planned | — | GET,POST /warehouse-user-assignments<br>GET,PATCH,DELETE /warehouse-user-assignments/{id} |
-| WarehousesBackendApi | BackendAPI | Planned | — | GET /warehouses |
+| Module | Category | Status | Released In | Requires | Key endpoints |
+|---|---|---|---|---|---|
+| CartNotesBackendApi | Extension-Only BackendAPI | Planned | — | SalesOrdersBackendApi | (extension-only) |
+| CategoriesBackendApi | BackendAPI | Planned | — | — | GET,POST /categories<br>GET,PATCH /categories/{id} |
+| DynamicEntityBackendApi | BackendAPI | Planned | — | — | GET,POST,PATCH,PUT /dynamic-entity/{entity-name} (~62 auto-generated entity endpoints) |
+| OauthBackendApi | BackendAPI | Planned | — | — | POST /token |
+| PickingListsBackendApi | BackendAPI | Planned | — | — | GET /picking-lists<br>GET /picking-lists/{id}<br>PATCH /picking-lists/{id}/picking-list-items/{id}<br>POST /start-picking |
+| PickingListsUsersBackendApi | Extension-Only BackendAPI | Planned | — | PickingListsBackendApi, UsersBackendApi | (extension-only) |
+| PickingListsWarehousesBackendApi | Extension-Only BackendAPI | Planned | — | PickingListsBackendApi, WarehousesBackendApi | (extension-only) |
+| ProductAttributesBackendApi | BackendAPI | Planned | — | — | GET,POST /product-attributes<br>GET,PATCH /product-attributes/{id} |
+| ProductImageSetsBackendApi | BackendAPI | Planned | — | — | GET /concrete-product-image-sets |
+| ProductPackagingUnitsBackendApi | Extension-Only BackendAPI | Planned | — | PickingListsBackendApi | (extension-only) |
+| ProductsBackendApi | BackendAPI | Planned | — | — | GET,POST /product-abstract<br>DELETE,GET,PATCH /product-abstract/{id} |
+| PushNotificationsBackendApi | BackendAPI | Planned | — | — | GET,POST /push-notification-providers<br>PATCH,DELETE /push-notification-providers/{id}<br>POST /push-notification-subscriptions |
+| SalesOrdersBackendApi | BackendAPI | Planned | — | — | GET /sales-orders |
+| ServicePointsBackendApi | BackendAPI | Planned | — | — | GET,POST /service-points<br>GET,PATCH /service-points/{id}<br>GET,POST /service-point-addresses<br>PATCH /service-points/{id}/service-point-addresses/{id}<br>GET,POST /service-types<br>GET,PATCH /service-types/{id}<br>GET,POST /services<br>GET,PATCH /services/{id} |
+| ShipmentTypesBackendApi | BackendAPI | Planned | — | — | GET,POST /shipment-types<br>GET,PATCH /shipment-types/{id} |
+| ShipmentsBackendApi | BackendAPI | Planned | — | — | GET /sales-shipments |
+| StoresBackendApi | BackendAPI | Planned | — | — | GET,POST,PATCH /stores |
+| UsersBackendApi | BackendAPI | Planned | — | — | GET /users |
+| WarehouseOauthBackendApi | BackendAPI | Planned | — | — | POST /warehouse-tokens |
+| WarehouseUsersBackendApi | BackendAPI | Planned | — | — | GET,POST /warehouse-user-assignments<br>GET,PATCH,DELETE /warehouse-user-assignments/{id} |
+| WarehousesBackendApi | BackendAPI | Planned | — | — | GET /warehouses |


### PR DESCRIPTION
Adds a "Released In" version column to the Storefront and Backend API migration status tables.

Jira: https://spryker.atlassian.net/browse/CC-38958
