### PR TITLE
CC-39235: align API Platform migration docs

### DIFF
--- a/docs/dg/dev/architecture/api-platform.md
+++ b/docs/dg/dev/architecture/api-platform.md
@@ -38,6 +38,19 @@ API Platform is a framework for building modern APIs based on web standards and 
 
 Read more about the API Platform project at [api-platform.com](https://api-platform.com/).
 
+### Why Spryker is moving to API Platform
+
+API Platform replaces Spryker-specific patterns for routing, authentication, and resource definition with industry-standard Symfony conventions, automatic OpenAPI schema generation, and a clean separation between resource schema, provider, and validation.
+
+| Aspect | Previous infrastructure | API Platform |
+|---|---|---|
+| Bootstrap | Spryker-specific application bootstrap | Symfony Kernel-based routing |
+| Resource registration | Manual plugin registration in `GlueApplicationDependencyProvider` | Declarative YAML resource definitions (`*.resource.yml`) |
+| Authentication | Custom flows per module | Standard OAuth2 / Symfony Security |
+| Coupling | Tight coupling between resource and routing logic | Clean separation: provider + resource schema + validation |
+| Testability | Complex to test and extend | Symfony-native, testable with standard PHPUnit patterns |
+| OpenAPI | Manual / partial | Automatic OpenAPI schema generation |
+
 ## Architecture overview
 
 ### Resource generation workflow
@@ -280,7 +293,7 @@ $services->load('Pyz\\Zed\\', '../../../src/Pyz/Zed/');
 Providers and Processors are automatically discovered and can use constructor injection:
 
 ```php
-class CustomerBackofficeProvider implements ProviderInterface
+class CustomerBackendProvider implements ProviderInterface
 {
     public function __construct(
         private CustomerFacadeInterface $customerFacade,

--- a/docs/dg/dev/architecture/api-platform/configuration.md
+++ b/docs/dg/dev/architecture/api-platform/configuration.md
@@ -16,15 +16,73 @@ related:
     link: docs/dg/dev/architecture/api-platform/security.html
 ---
 
-Spryker uses [API Platform's configuration options](https://api-platform.com/docs/core/configuration/#symfony-configuration) with Spryker-specific adaptations for PHP-based configuration and environment control.
+This page is the canonical reference for all API Platform configuration in Spryker. API Platform is configured through **two** PHP config files per application: the native `api_platform.php` (API Platform's own options, with Spryker adaptations for PHP-based configuration and environment control) and Spryker's `spryker_api_platform.php` (which drives schema generation). Both are documented below.
 
 ## Configuration file locations
 
-Configuration files are located in application-specific directories:
+Each application layer carries two configuration files:
 
-- **GlueBackend:** `config/GlueBackend/packages/api_platform.php`
-- **GlueStorefront:** `config/GlueStorefront/packages/api_platform.php`
-- **Glue:** `config/Glue/packages/api_platform.php`
+| Application | Native API Platform config | Spryker generator config |
+|---|---|---|
+| Glue | `config/Glue/packages/api_platform.php` | `config/Glue/packages/spryker_api_platform.php` |
+| GlueStorefront | `config/GlueStorefront/packages/api_platform.php` | `config/GlueStorefront/packages/spryker_api_platform.php` |
+| GlueBackend | `config/GlueBackend/packages/api_platform.php` | `config/GlueBackend/packages/spryker_api_platform.php` |
+
+- **`api_platform.php`** configures API Platform itself (Swagger, formats, pagination defaults, resource mapping paths). Documented under [Native API Platform configuration](#native-api-platform-configuration-api_platformphp) below.
+- **`spryker_api_platform.php`** configures Spryker's schema generator (which API types an application serves, where schemas are scanned, which modules stay on Glue). Documented under [Resource generation configuration](#resource-generation-configuration-spryker_api_platformphp) below.
+
+## Released configuration reference
+
+The simplest starting point is a real, released configuration. The links below point to the B2B Demo Marketplace at the latest release (`release-202604.0`); check newer releases for updates.
+
+| Application | `api_platform.php` | `spryker_api_platform.php` |
+|---|---|---|
+| Glue | [api_platform.php](https://github.com/spryker-shop/b2b-demo-marketplace/blob/release-202604.0/config/Glue/packages/api_platform.php) | [spryker_api_platform.php](https://github.com/spryker-shop/b2b-demo-marketplace/blob/release-202604.0/config/Glue/packages/spryker_api_platform.php) |
+| GlueStorefront | [api_platform.php](https://github.com/spryker-shop/b2b-demo-marketplace/blob/release-202604.0/config/GlueStorefront/packages/api_platform.php) | [spryker_api_platform.php](https://github.com/spryker-shop/b2b-demo-marketplace/blob/release-202604.0/config/GlueStorefront/packages/spryker_api_platform.php) |
+| GlueBackend | [api_platform.php](https://github.com/spryker-shop/b2b-demo-marketplace/blob/release-202604.0/config/GlueBackend/packages/api_platform.php) | [spryker_api_platform.php](https://github.com/spryker-shop/b2b-demo-marketplace/blob/release-202604.0/config/GlueBackend/packages/spryker_api_platform.php) |
+
+## Resource generation configuration (`spryker_api_platform.php`)
+
+`spryker_api_platform.php` controls Spryker's API Platform schema generator — it is separate from the native `api_platform.php`. Create one in each application layer where you enable API Platform. The files share the same shape; they differ only in `apiTypes()` and in the modules each application still serves via Glue.
+
+Three settings:
+
+- `apiTypes()` — the API types this application serves: `['storefront']` for the Glue and GlueStorefront applications, `['backend']` for the GlueBackend application.
+- `sourceDirectories()` — where the generator scans for API Platform schemas. Optional; defaults to `src/Spryker`, `src/SprykerFeature`, and `src/Pyz`. Set it only if your schemas live somewhere else.
+- `excludedPathFragments()` — schema paths the generator skips. Use it to keep a module's API Platform schemas hidden from the generator (for example, a module the project still serves via Glue). Each entry is matched as a substring of the full schema path.
+
+{% info_block warningBox "excludedPathFragments does not switch routing" %}
+
+`excludedPathFragments` controls only what the schema generator emits. It does **not** flip routing. A module stays on Glue as long as its `*ResourceRoutePlugin` is registered in the project dependency provider. See [Step 3 — Batch migration in the migration overview](/docs/dg/dev/upgrade-and-migrate/migrate-to-api-platform-overview.html#step-3--batch-migration-default).
+
+{% endinfo_block %}
+
+`config/Glue/packages/spryker_api_platform.php` (storefront example):
+
+```php
+<?php
+
+declare(strict_types = 1);
+
+use Symfony\Config\SprykerApiPlatformConfig;
+
+return static function (SprykerApiPlatformConfig $sprykerApiPlatform): void {
+    $sprykerApiPlatform->apiTypes(['storefront']);
+
+    // Keep these modules on the Glue REST stack by hiding their API Platform schemas from the generator.
+    $sprykerApiPlatform->excludedPathFragments([
+        'vendor/spryker/customer/src/Spryker/Customer/resources/api/',
+        'vendor/spryker/store/src/Spryker/Store/resources/api/',
+        'vendor/spryker/authentication/src/Spryker/Authentication/resources/api/',
+    ]);
+};
+```
+
+For the GlueBackend application, set `apiTypes(['backend'])` and list the modules that application still serves via Glue in `excludedPathFragments()`.
+
+## Native API Platform configuration (`api_platform.php`)
+
+The remainder of this page documents `api_platform.php`.
 
 ## Spryker-specific differences
 

--- a/docs/dg/dev/architecture/api-platform/configuration.md
+++ b/docs/dg/dev/architecture/api-platform/configuration.md
@@ -28,8 +28,8 @@ Each application layer carries two configuration files:
 | GlueStorefront | `config/GlueStorefront/packages/api_platform.php` | `config/GlueStorefront/packages/spryker_api_platform.php` |
 | GlueBackend | `config/GlueBackend/packages/api_platform.php` | `config/GlueBackend/packages/spryker_api_platform.php` |
 
-- **`api_platform.php`** configures API Platform itself (Swagger, formats, pagination defaults, resource mapping paths). Documented under [Native API Platform configuration](#native-api-platform-configuration-api_platformphp) below.
-- **`spryker_api_platform.php`** configures Spryker's schema generator (which API types an application serves, where schemas are scanned, which modules stay on Glue). Documented under [Resource generation configuration](#resource-generation-configuration-spryker_api_platformphp) below.
+- **`api_platform.php`** configures API Platform itself (Swagger, formats, pagination defaults, resource mapping paths). Documented under [Native API Platform configuration](#native-api-platform-configuration-apiplatformphp) below.
+- **`spryker_api_platform.php`** configures Spryker's schema generator (which API types an application serves, where schemas are scanned, which modules stay on Glue). Documented under [Resource generation configuration](#resource-generation-configuration-sprykerapiplatformphp) below.
 
 ## Released configuration reference
 
@@ -41,7 +41,7 @@ The simplest starting point is a real, released configuration. The links below p
 | GlueStorefront | [api_platform.php](https://github.com/spryker-shop/b2b-demo-marketplace/blob/release-202604.0/config/GlueStorefront/packages/api_platform.php) | [spryker_api_platform.php](https://github.com/spryker-shop/b2b-demo-marketplace/blob/release-202604.0/config/GlueStorefront/packages/spryker_api_platform.php) |
 | GlueBackend | [api_platform.php](https://github.com/spryker-shop/b2b-demo-marketplace/blob/release-202604.0/config/GlueBackend/packages/api_platform.php) | [spryker_api_platform.php](https://github.com/spryker-shop/b2b-demo-marketplace/blob/release-202604.0/config/GlueBackend/packages/spryker_api_platform.php) |
 
-## Resource generation configuration (`spryker_api_platform.php`)
+## Resource generation configuration (spryker_api_platform.php)
 
 `spryker_api_platform.php` controls Spryker's API Platform schema generator — it is separate from the native `api_platform.php`. Create one in each application layer where you enable API Platform. The files share the same shape; they differ only in `apiTypes()` and in the modules each application still serves via Glue.
 
@@ -80,9 +80,9 @@ return static function (SprykerApiPlatformConfig $sprykerApiPlatform): void {
 
 For the GlueBackend application, set `apiTypes(['backend'])` and list the modules that application still serves via Glue in `excludedPathFragments()`.
 
-## Native API Platform configuration (`api_platform.php`)
+## Native API Platform configuration (api_platform.php)
 
-The remainder of this page documents `api_platform.php`.
+`api_platform.php` configures API Platform itself. Spryker ships working defaults, so most projects only adjust a few options. The sections below cover the Spryker-specific adaptations and the settings you are most likely to change.
 
 ## Spryker-specific differences
 

--- a/docs/dg/dev/architecture/api-platform/configuration.md
+++ b/docs/dg/dev/architecture/api-platform/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: API Platform Configuration
 description: Configure API Platform in Spryker using PHP-based configuration files with environment-specific settings.
-last_updated: Mar 9, 2026
+last_updated: Jun 16, 2026
 template: howto-guide-template
 related:
   - title: API Platform

--- a/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
+++ b/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
@@ -29,53 +29,11 @@ This page does **not** describe how to integrate API Platform into your project.
 
 {% endinfo_block %}
 
-## Why Spryker is moving to API Platform
+## How to migrate a module
 
-API Platform replaces Spryker-specific patterns for routing, authentication, and resource definition with industry-standard Symfony conventions, automatic OpenAPI schema generation, and a clean separation between resource schema, provider, and validation.
+The end-to-end migration steps — upgrade the module, confirm configuration, flip routing, verify, and clean up — are owned by the [API Platform migration overview](/docs/dg/dev/upgrade-and-migrate/migrate-to-api-platform-overview.html). This page only tracks **which** modules are available on API Platform and their status.
 
-| Aspect | Previous infrastructure | API Platform |
-|---|---|---|
-| Bootstrap | Spryker-specific application bootstrap | Symfony Kernel-based routing |
-| Resource registration | Manual plugin registration in `GlueApplicationDependencyProvider` | Declarative YAML resource definitions (`*.resource.yml`) |
-| Authentication | Custom flows per module | Standard OAuth2 / Symfony Security |
-| Coupling | Tight coupling between resource and routing logic | Clean separation: provider + resource schema + validation |
-| Testability | Complex to test and extend | Symfony-native, testable with standard PHPUnit patterns |
-| OpenAPI | Manual / partial | Automatic OpenAPI schema generation |
-
-## General migration workflow
-
-For any module marked **Migrated**, projects upgrade in three high-level steps. Detailed instructions are in the linked integration guides above.
-
-1. **Update the module to the API Platform-enabled version**
-
-   Pull the new module version that ships the `*.resource.yml` schema and Provider class:
-
-    ```bash
-    composer update spryker/<module-name>
-    ```
-
-2. **Remove the previous resource plugins**
-
-   In your project's `GlueApplicationDependencyProvider`, remove the previous plugin registrations for the migrated module - typically a `ResourceRoutePlugin` (and any related `ResourceRelationshipPlugin` / expander plugins) registered in `getResourceRoutePlugins()`.
-
-   For **extension-only** modules, remove or replace the corresponding plugin wiring in the parent module's dependency provider as indicated in the module's release notes.
-
-3. **Clear caches and verify**
-
-    ```bash
-    docker/sdk cli glue cache:clear
-    docker/sdk cli glue api:generate
-    ```
-
-   Confirm the endpoint is served by API Platform by hitting it against your local Glue host - the response is now produced by the new Symfony-based stack.
-
-{% info_block infoBox "Parallel operation" %}
-
-The previous API stack and API Platform run **side by side** during the transition. You can migrate modules incrementally; modules that have not been migrated continue to be served by the previous stack.
-
-{% endinfo_block %}
-
-### Status legend
+## Status legend
 
 | Status | Meaning |
 |---|---|

--- a/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
+++ b/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
@@ -63,8 +63,8 @@ For any module marked **Migrated**, projects upgrade in three high-level steps. 
 3. **Clear caches and verify**
 
     ```bash
-    vendor/bin/glue cache:clear
-    vendor/bin/glue api:generate
+    docker/sdk cli glue cache:clear
+    docker/sdk cli glue api:generate
     ```
 
    Confirm the endpoint is served by API Platform by hitting it against your local Glue host - the response is now produced by the new Symfony-based stack.

--- a/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
+++ b/docs/dg/dev/architecture/api-platform/migrate-to-api-platform-status.md
@@ -1,6 +1,6 @@
 ---
 title: Migration status - Glue API to API Platform
-description: Tracks the migration status of API modules to the Spryker API Platform across StorefrontAPI and BackendAPI, with endpoint coverage and a high-level migration workflow.
+description: Tracks the migration status of API modules to the Spryker API Platform across StorefrontAPI and BackendAPI, with endpoint coverage.
 last_updated: Jun 10, 2026
 template: howto-guide-template
 redirect_from:

--- a/docs/dg/dev/architecture/api-platform/troubleshooting.md
+++ b/docs/dg/dev/architecture/api-platform/troubleshooting.md
@@ -271,6 +271,26 @@ The `assets:install` command must be run after integrating API Platform and when
    ✅ /customers
    ```
 
+### Requests without an `Accept` header are rejected or return the wrong format
+
+**Symptom:** A client request that omits the `Accept` header — or sends only `Accept: */*` — returns `406 Not Acceptable`, or a response in a format other than the legacy `application/vnd.api+json`. The legacy Glue REST API silently accepted the same request and answered with `application/vnd.api+json`.
+
+**Cause:** API Platform runs content negotiation that requires a satisfiable `Accept` header and does not assume the legacy Glue default. This is a behavioral difference from the legacy Glue REST stack.
+
+**Solution:**
+
+1. Upgrade `spryker/api-platform` to **1.15.0 or higher**. Its `AcceptHeaderFallbackSubscriber` restores the legacy behavior — a missing or `*/*` `Accept` header defaults to `application/vnd.api+json`:
+
+   ```bash
+   composer update spryker/api-platform --with-dependencies
+   ```
+
+2. If you cannot upgrade, send an explicit `Accept` header from the client:
+
+   ```bash
+   curl -H "Accept: application/vnd.api+json" https://glue-backend.mysprykershop.com/customers
+   ```
+
 ### Pagination not working
 
 **Symptom:** All results returned instead of paginated response.
@@ -450,7 +470,7 @@ If you encounter issues not covered here:
 3. **Validate environment:**
 
    ```bash
-   php -v  # Check PHP version (8.1+)
+   php -v  # Check PHP version (8.3+)
    composer show | grep api-platform
    docker/sdk cli glue  debug:container | grep -i api
    ```

--- a/docs/dg/dev/upgrade-and-migrate/integrate-api-platform.md
+++ b/docs/dg/dev/upgrade-and-migrate/integrate-api-platform.md
@@ -63,35 +63,9 @@ The `SecurityBundle` enables authentication and authorization for API Platform r
 
 ## 3. Configure API Platform
 
-Create a `spryker_api_platform.php` config file in each application layer where you want to enable API Platform — `config/Glue/packages/`, `config/GlueStorefront/packages/`, and `config/GlueBackend/packages/`. The files share the same shape; they differ only in `apiTypes()` (`['storefront']` for the Glue and GlueStorefront applications, `['backend']` for the GlueBackend application) and in the modules each application still serves via Glue.
+Create a `spryker_api_platform.php` and an `api_platform.php` file in each application layer where you enable API Platform — `config/Glue/packages/`, `config/GlueStorefront/packages/`, and `config/GlueBackend/packages/`. At minimum, `spryker_api_platform.php` must set the application's `apiTypes()` — `['storefront']` for the Glue and GlueStorefront applications, `['backend']` for the GlueBackend application.
 
-Two settings deserve attention:
-
-- `sourceDirectories()` — where the generator scans for API Platform schemas. Optional; it defaults to `src/Spryker`, `src/SprykerFeature`, and `src/Pyz`. Set it only if your schemas live somewhere else.
-- `excludedPathFragments()` — schema paths the generator skips. Use it to keep a module's API Platform schemas hidden from the generator (for example, a module the project still serves via Glue). Each entry is matched as a substring of the full schema path. This does NOT switch routing — see [Step 3 — Batch migration in the overview](/docs/dg/dev/upgrade-and-migrate/migrate-to-api-platform-overview.html#step-3--batch-migration-default) for how routing actually flips.
-
-`config/Glue/packages/spryker_api_platform.php` (storefront example):
-
-```php
-<?php
-
-declare(strict_types = 1);
-
-use Symfony\Config\SprykerApiPlatformConfig;
-
-return static function (SprykerApiPlatformConfig $sprykerApiPlatform): void {
-    $sprykerApiPlatform->apiTypes(['storefront']);
-
-    // Keep these modules on the Glue REST stack by hiding their API Platform schemas from the generator.
-    $sprykerApiPlatform->excludedPathFragments([
-        'vendor/spryker/customer/src/Spryker/Customer/resources/api/',
-        'vendor/spryker/store/src/Spryker/Store/resources/api/',
-        'vendor/spryker/authentication/src/Spryker/Authentication/resources/api/',
-    ]);
-};
-```
-
-For the GlueBackend application, set `apiTypes(['backend'])` and list the modules that application still serves via Glue in `excludedPathFragments()` (for example `vendor/spryker/store/src/Spryker/Store/resources/api/`, `vendor/spryker/currency/src/Spryker/Currency/resources/api/`, `vendor/spryker/locale/src/Spryker/Locale/resources/api/`, `vendor/spryker/store-context/src/Spryker/StoreContext/resources/api/`).
+For the full reference of both configuration files, every available setting, and links to the released demo-shop configurations, see [API Platform Configuration](/docs/dg/dev/architecture/api-platform/configuration.html).
 
 ## 4. Update Router Configuration
 
@@ -137,30 +111,16 @@ When migrating existing Glue API endpoints to API Platform, you need to remove e
 
 ## 5. Generate API resources
 
-After configuration, generate your API resources from schema files:
+After configuration, generate your API resources from the schema files:
 
 ```bash
-# Generate resources for all configured API types in Glue
+# Generate resources for all configured API types
 docker/sdk cli glue api:generate
-
-# Generate resources for all configured API types in GlueStorefront
-docker/sdk cli GLUE_APPLICATION=GLUE_STOREFRONT glue api:generate
-
-# Generate resources for all configured API types in GlueBackend
-docker/sdk cli GLUE_APPLICATION=GLUE_BACKEND glue api:generate
-
-# Generate resources for a specific API type in Glue (others can follow the env var examples above)
-docker/sdk cli glue api:generate storefront
-docker/sdk cli glue api:generate backend
-
-# Dry run (see what would be generated)
-docker/sdk cli glue api:generate --dry-run
-
-# Validate schemas only
-docker/sdk cli glue api:generate --validate-only
 ```
 
-The generated resources will be created in `src/Generated/Api/{ApiType}/` directory.
+Target a specific application by prefixing with `GLUE_APPLICATION=GLUE_STOREFRONT` or `GLUE_APPLICATION=GLUE_BACKEND`. For the full set of generation and debug commands (single API type, `--dry-run`, `--validate-only`, schema inspection), see [Resource generation](/docs/dg/dev/architecture/api-platform.html#resource-generation) in the architecture guide.
+
+The generated resources are created in `src/Generated/Api/{ApiType}/`.
 
 ## 6. Install assets for the API Platform documentation interface
 

--- a/docs/dg/dev/upgrade-and-migrate/integrate-api-platform.md
+++ b/docs/dg/dev/upgrade-and-migrate/integrate-api-platform.md
@@ -14,7 +14,7 @@ If you're migrating an existing Spryker shop from the Glue REST stack, read the 
 Before integrating API Platform, ensure you have:
 
 - Upgraded to Symfony Dependency Injection as described in [How to upgrade to Symfony Dependency Injection](/docs/dg/dev/upgrade-and-migrate/upgrade-to-symfony-dependency-injection.html)
-- PHP 8.1 or higher
+- PHP 8.3 or higher
 - Symfony 6.4 or higher components
 
 ## 1. Install the required modules

--- a/docs/dg/dev/upgrade-and-migrate/migrate-to-api-platform-overview.md
+++ b/docs/dg/dev/upgrade-and-migrate/migrate-to-api-platform-overview.md
@@ -29,6 +29,12 @@ Once a module is migrated, its endpoint wiring is the API Platform resource sche
 
 {% endinfo_block %}
 
+{% info_block warningBox "One client-visible behavior change: the Accept header" %}
+
+Backward compatibility has one exception. Legacy Glue REST accepted requests that omitted the `Accept` header (or sent `*/*`) and answered with `application/vnd.api+json`. API Platform's content negotiation does not, so such clients can receive `406 Not Acceptable` or a response in a different format. `spryker/api-platform` **1.15.0+** restores the legacy fallback. See [Requests without an Accept header](/docs/dg/dev/architecture/api-platform/troubleshooting.html#requests-without-an-accept-header-are-rejected-or-return-the-wrong-format) in troubleshooting.
+
+{% endinfo_block %}
+
 ## Prerequisites
 
 Before starting the migration, confirm:

--- a/docs/dg/dev/upgrade-and-migrate/migrate-to-api-platform.md
+++ b/docs/dg/dev/upgrade-and-migrate/migrate-to-api-platform.md
@@ -41,59 +41,9 @@ Before migrating resources, ensure you have:
 - Configured router plugins in correct order (see below)
 - Tested that API Platform is working with at least one test resource
 
-## Migration strategy
+## Migration strategy and router setup
 
-Whether you migrate a single module or a batch, the same safety properties hold:
-
-1. **Coexistence**: Both Glue API and API Platform run side by side
-2. **Router priority**: Existing Glue endpoints are matched first, API Platform endpoints second
-3. **Resource-by-resource mechanics**: Within a batch, apply the steps below to each resource, then verify before moving to the next
-4. **No breaking changes**: Existing API consumers continue to work during migration
-5. **Final cleanup**: Remove Glue router only after all resources are migrated
-
-### Router configuration order
-
-The key to gradual migration is router plugin order. The `SymfonyFrameworkRouterPlugin` must be placed **after** existing Glue router plugins:
-
-`src/Pyz/Glue/Router/RouterDependencyProvider.php`
-
-```php
-<?php
-
-declare(strict_types = 1);
-
-namespace Pyz\Glue\Router;
-
-use Spryker\Glue\GlueApplication\Plugin\Rest\GlueRouterPlugin;
-use Spryker\Glue\Router\Plugin\Router\SymfonyFrameworkRouterPlugin;
-use Spryker\Glue\Router\RouterDependencyProvider as SprykerRouterDependencyProvider;
-
-class RouterDependencyProvider extends SprykerRouterDependencyProvider
-{
-    /**
-     * @return array<\Spryker\Glue\RouterExtension\Dependency\Plugin\RouterPluginInterface>
-     */
-    protected function getRouterPlugins(): array
-    {
-        return [
-            new GlueRouterPlugin(),        // ← Existing Glue endpoints (checked first)
-            new SymfonyFrameworkRouterPlugin(),     // ← API Platform endpoints (checked second)
-        ];
-    }
-}
-```
-
-{% info_block warningBox "Router order is critical" %}
-
-If `SymfonyFrameworkRouterPlugin` is placed before `GlueRouterPlugin`, API Platform routes may shadow existing Glue routes and break backward compatibility. Always place it **after** existing routers.
-
-{% endinfo_block %}
-
-With this configuration:
-- Request comes in: `GET /customers`
-- `GlueRouterPlugin` checks first: If Glue resource exists → use it
-- `SymfonyFrameworkRouterPlugin` checks second: If no Glue match → try API Platform
-- Result: Existing endpoints continue working, new API Platform endpoints are available
+This guide covers the mechanics of migrating a single resource. The overall strategy (batch migration is the default), the router-plugin ordering, and how routing flips between Glue and API Platform are owned by the [API Platform migration overview](/docs/dg/dev/upgrade-and-migrate/migrate-to-api-platform-overview.html) — read it first. The steps below are what you apply to each resource within a batch.
 
 ## Migration process
 

--- a/docs/dg/dev/upgrade-and-migrate/migrate-to-api-platform.md
+++ b/docs/dg/dev/upgrade-and-migrate/migrate-to-api-platform.md
@@ -31,7 +31,7 @@ Migrating from Glue API to API Platform provides several benefits:
 - **Standardized pagination**: Consistent pagination across all resources
 - **Better maintainability**: Clearer separation of concerns with providers and processors
 
-The migration can be done gradually, resource by resource, without breaking existing API consumers.
+The recommended default is **batch migration** — migrating a group of related modules together, as described in the [API Platform migration overview](/docs/dg/dev/upgrade-and-migrate/migrate-to-api-platform-overview.html). The per-resource steps below are the mechanics you apply to each resource *within* a batch; none of it breaks existing API consumers.
 
 ## Prerequisites
 
@@ -43,11 +43,11 @@ Before migrating resources, ensure you have:
 
 ## Migration strategy
 
-The migration follows a **gradual replacement** approach:
+Whether you migrate a single module or a batch, the same safety properties hold:
 
 1. **Coexistence**: Both Glue API and API Platform run side by side
 2. **Router priority**: Existing Glue endpoints are matched first, API Platform endpoints second
-3. **Resource-by-resource**: Migrate one resource at a time, verify, then move to the next
+3. **Resource-by-resource mechanics**: Within a batch, apply the steps below to each resource, then verify before moving to the next
 4. **No breaking changes**: Existing API consumers continue to work during migration
 5. **Final cleanup**: Remove Glue router only after all resources are migrated
 
@@ -165,16 +165,16 @@ Create the equivalent API Platform schema for the resource.
 
 **Create schema file:**
 
-`src/Pyz/Zed/Customer/resources/api/backoffice/customers.yml`
+`src/Pyz/Zed/Customer/resources/api/backend/customers.yml`
 
 ```yaml
 resource:
     name: Customers
     shortName: Customer
-    description: "Customer resource for backoffice API"
+    description: "Customer resource for backend API"
 
-    provider: "Pyz\\Glue\\Customer\\Api\\Backoffice\\Provider\\CustomerBackofficeProvider"
-    processor: "Pyz\\Glue\\Customer\\Api\\Backoffice\\Processor\\CustomerBackofficeProcessor"
+    provider: "Pyz\\Glue\\Customer\\Api\\Backend\\Provider\\CustomerBackendProvider"
+    processor: "Pyz\\Glue\\Customer\\Api\\Backend\\Processor\\CustomerBackendProcessor"
 
     paginationEnabled: true
     paginationItemsPerPage: 10
@@ -215,7 +215,7 @@ resource:
 
 **Create validation schema:**
 
-`src/Pyz/Zed/Customer/resources/api/backoffice/customers.validation.yml`
+`src/Pyz/Zed/Customer/resources/api/backend/customers.validation.yml`
 
 ```yaml
 post:
@@ -250,20 +250,20 @@ The Provider should primarily call existing Facade methods. This ensures consist
 
 {% endinfo_block %}
 
-`src/Pyz/Zed/Customer/Api/Backoffice/Provider/CustomerBackofficeProvider.php`
+`src/Pyz/Zed/Customer/Api/Backend/Provider/CustomerBackendProvider.php`
 
 ```php
 <?php
 
-namespace Pyz\Zed\Customer\Api\Backoffice\Provider;
+namespace Pyz\Zed\Customer\Api\Backend\Provider;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\Pagination\TraversablePaginator;
 use ApiPlatform\State\ProviderInterface;
-use Generated\Api\Backoffice\CustomersBackofficeResource;
+use Generated\Api\Backend\CustomersBackendResource;
 use Spryker\Zed\Customer\Business\CustomerFacadeInterface;
 
-class CustomerBackofficeProvider implements ProviderInterface
+class CustomerBackendProvider implements ProviderInterface
 {
     public function __construct(
         private CustomerFacadeInterface $customerFacade,
@@ -279,7 +279,7 @@ class CustomerBackofficeProvider implements ProviderInterface
         return $this->getCustomers($context);
     }
 
-    private function getCustomer(string $customerReference): ?CustomersBackofficeResource
+    private function getCustomer(string $customerReference): ?CustomersBackendResource
     {
         // Reuse existing Glue logic
         $customerTransfer = $this->customerFacade->findCustomerByReference($customerReference);
@@ -289,7 +289,7 @@ class CustomerBackofficeProvider implements ProviderInterface
         }
 
         // Map transfer to API Platform resource
-        $resource = new CustomersBackofficeResource();
+        $resource = new CustomersBackendResource();
         $resource->fromArray($customerTransfer->toArray());
 
         return $resource;
@@ -306,7 +306,7 @@ class CustomerBackofficeProvider implements ProviderInterface
 
         $resources = [];
         foreach ($customerCollection->getCustomers() as $customerTransfer) {
-            $resource = new CustomersBackofficeResource();
+            $resource = new CustomersBackendResource();
             $resource->fromArray($customerTransfer->toArray());
             $resources[] = $resource;
         }
@@ -331,22 +331,22 @@ The Processor should primarily call existing Facade methods. This ensures consis
 
 {% endinfo_block %}
 
-`src/Pyz/Zed/Customer/Api/Backoffice/Processor/CustomerBackofficeProcessor.php`
+`src/Pyz/Zed/Customer/Api/Backend/Processor/CustomerBackendProcessor.php`
 
 ```php
 <?php
 
-namespace Pyz\Zed\Customer\Api\Backoffice\Processor;
+namespace Pyz\Zed\Customer\Api\Backend\Processor;
 
 use ApiPlatform\Metadata\Operation;
 use ApiPlatform\Metadata\Patch;
 use ApiPlatform\Metadata\Post;
 use ApiPlatform\State\ProcessorInterface;
-use Generated\Api\Backoffice\CustomersBackofficeResource;
+use Generated\Api\Backend\CustomersBackendResource;
 use Generated\Shared\Transfer\CustomerTransfer;
 use Spryker\Zed\Customer\Business\CustomerFacadeInterface;
 
-class CustomerBackofficeProcessor implements ProcessorInterface
+class CustomerBackendProcessor implements ProcessorInterface
 {
     public function __construct(
         private CustomerFacadeInterface $customerFacade,
@@ -366,7 +366,7 @@ class CustomerBackofficeProcessor implements ProcessorInterface
         return null;
     }
 
-    private function createCustomer(CustomersBackofficeResource $resource): CustomersBackofficeResource
+    private function createCustomer(CustomersBackendResource $resource): CustomersBackendResource
     {
         $customerTransfer = new CustomerTransfer();
         $customerTransfer->fromArray($resource->toArray(), true);
@@ -374,13 +374,13 @@ class CustomerBackofficeProcessor implements ProcessorInterface
         // Reuse existing facade method
         $customerResponseTransfer = $this->customerFacade->addCustomer($customerTransfer);
 
-        $result = new CustomersBackofficeResource();
+        $result = new CustomersBackendResource();
         $result->fromArray($customerResponseTransfer->getCustomerTransfer()->toArray());
 
         return $result;
     }
 
-    private function updateCustomer(CustomersBackofficeResource $resource, string $customerReference): CustomersBackofficeResource
+    private function updateCustomer(CustomersBackendResource $resource, string $customerReference): CustomersBackendResource
     {
         $customerTransfer = new CustomerTransfer();
         $customerTransfer->fromArray($resource->toArray(), true);
@@ -389,7 +389,7 @@ class CustomerBackofficeProcessor implements ProcessorInterface
         // Reuse existing facade method
         $customerResponseTransfer = $this->customerFacade->updateCustomer($customerTransfer);
 
-        $result = new CustomersBackofficeResource();
+        $result = new CustomersBackendResource();
         $result->fromArray($customerResponseTransfer->getCustomerTransfer()->toArray());
 
         return $result;
@@ -399,19 +399,13 @@ class CustomerBackofficeProcessor implements ProcessorInterface
 
 ### Step 6: Generate API Platform resource
 
-Generate the Back Office resource class from the schema:
+Generate the backend resource class from the schema:
 
 ```bash
-console api:generate
+docker/sdk cli GLUE_APPLICATION=GLUE_BACKEND glue api:generate
 
 # Verify generation
-ls -la src/Generated/Api/Backoffice/CustomersBackofficeResource.php
-```
-
-Generate the storefront resource class from the schema:
-
-```bash
-glue api:generate storefront
+ls -la src/Generated/Api/Backend/CustomersBackendResource.php
 ```
 
 ### Step 7: Test the API Platform endpoint
@@ -420,18 +414,18 @@ Test that the new endpoint works correctly:
 
 ```bash
 # Test single resource
-curl -X GET http://backoffice.eu.spryker.local/customers/DE--1
+curl -X GET http://glue-backend.eu.spryker.local/customers/DE--1
 
 # Test collection
-curl -X GET http://backoffice.eu.spryker.local/customers?page=1&itemsPerPage=10
+curl -X GET http://glue-backend.eu.spryker.local/customers?page=1&itemsPerPage=10
 
 # Test create
-curl -X POST http://backoffice.eu.spryker.local/customers \
+curl -X POST http://glue-backend.eu.spryker.local/customers \
   -H "Content-Type: application/json" \
   -d '{"email":"test@example.com","firstName":"John","lastName":"Doe"}'
 
 # Test update
-curl -X PATCH http://backoffice.eu.spryker.local/customers/DE--1 \
+curl -X PATCH http://glue-backend.eu.spryker.local/customers/DE--1 \
   -H "Content-Type: application/json" \
   -d '{"firstName":"Jane"}'
 ```
@@ -505,13 +499,13 @@ After removing Glue resource files:
 console cache:clear
 
 # Test that API Platform endpoint still works
-curl -X GET http://backoffice.eu.spryker.local/customers/DE--1
+curl -X GET http://glue-backend.eu.spryker.local/customers/DE--1
 
 # Verify OpenAPI docs include the resource
-curl http://backoffice.eu.spryker.local/docs.json | jq '.paths'
+curl http://glue-backend.eu.spryker.local/docs.json | jq '.paths'
 
 # Check the interactive documentation at root URL
-# Visit: http://backoffice.eu.spryker.local/
+# Visit: http://glue-backend.eu.spryker.local/
 ```
 
 ### Step 11: Repeat for remaining resources
@@ -556,11 +550,11 @@ SymfonyFrameworkRouterPlugin
     ↓
 API Platform Router
     ↓
-CustomerBackofficeProvider
+CustomerBackendProvider
     ↓
 CustomerFacade (same!)
     ↓
-CustomersBackofficeResource
+CustomersBackendResource
     ↓
 Response: JSON (auto-serialized)
 ```
@@ -619,10 +613,10 @@ GET /customers/DE--1
 console cache:clear
 
 # Regenerate resources
-console|glue api:generate backoffice
+docker/sdk cli GLUE_APPLICATION=GLUE_BACKEND glue api:generate
 
 # Verify generated file exists
-ls -la src/Generated/Api/Backoffice/CustomersBackofficeResource.php
+ls -la src/Generated/Api/Backend/CustomersBackendResource.php
 ```
 
 ### Different response format between Glue and API Platform
@@ -661,9 +655,9 @@ $this->customerFacade->findCustomerByReference($customerReference); // ← Same 
 
 ## Best practices
 
-### 1. Migrate in small batches
+### 1. Keep batches small
 
-Don't try to migrate all resources at once. Migrate in small batches for example:
+Batch migration is the default (see the [migration overview](/docs/dg/dev/upgrade-and-migrate/migrate-to-api-platform-overview.html)), but keep each batch small and ship it before starting the next — don't try to migrate every resource in one go. For example:
 
 ```bash
 Sprint 1: Customers, Products (read-only)
@@ -677,14 +671,14 @@ Don't duplicate business logic in Providers/Processors:
 
 ```php
 // ❌ Bad: Logic in Provider
-private function getCustomer(string $reference): ?CustomersBackofficeResource
+private function getCustomer(string $reference): ?CustomersBackendResource
 {
     $customer = $this->repository->findByReference($reference);
     // ... business logic here
 }
 
 // ✅ Good: Delegate to Facade
-private function getCustomer(string $reference): ?CustomersBackofficeResource
+private function getCustomer(string $reference): ?CustomersBackendResource
 {
     $customerTransfer = $this->customerFacade->findCustomerByReference($reference);
     return $this->mapToResource($customerTransfer);
@@ -697,7 +691,7 @@ Leverage generated `toArray()` and `fromArray()` methods:
 
 ```php
 // Easy mapping between Transfer and Resource
-$resource = new CustomersBackofficeResource();
+$resource = new CustomersBackendResource();
 $resource->fromArray($customerTransfer->toArray());
 ```
 


### PR DESCRIPTION
## Summary

- Resolve the documentation action items from the API Platform Documentation check: unify the migration strategy on batch-as-default, fix the non-existent "Backoffice" API type in the per-module worked example, correct the PHP minimum, and standardize CLI commands.

## Ticket

CC-39235: https://spryker.atlassian.net/browse/CC-39235

## Test plan

- [ ] Pages render on the docs site with no broken internal links (overview ⇄ per-module ⇄ integrate cross-links resolve)
- [ ] Per-module worked example reads consistently as a `backend` API resource (paths, namespaces, classes, host, generate command)
- [ ] `api:generate` examples use the `docker/sdk cli glue …` form across integrate / per-module / status pages