### PR TITLE
Add images and expand AI Commerce docs with audit logs and multi-provider info

### DIFF
--- a/docs/dg/dev/ai/ai-commerce/configure-multiple-ai-providers.md
+++ b/docs/dg/dev/ai/ai-commerce/configure-multiple-ai-providers.md
@@ -1,11 +1,13 @@
 ---
 title: Configure multiple AI providers for AI Commerce
 description: Learn how to configure OpenAI, AWS Bedrock, and Anthropic providers independently for each AI Commerce feature.
-last_updated: May 11, 2026
+last_updated: Jun 15, 2026
 template: howto-guide-template
 ---
 
 AI Commerce supports three AI providers: OpenAI, AWS Bedrock, and Anthropic. Each feature — Back Office Assistant, Visual Add to Cart (Quick Order), Search by Image, and Smart PIM — can use a different provider independently. This lets you optimize cost, latency, or capability per feature without changing any application code.
+
+![Configure multiple AI providers](https://spryker.s3.eu-central-1.amazonaws.com/docs/dg/dev/ai-commerce/multiple-provider.png)
 
 ## How it works
 

--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.md
@@ -1,7 +1,7 @@
 ---
 title: AI Foundation Audit Logs
 description: Track and audit AI interactions with the AiFoundation module audit logging feature, including estimated cost per interaction.
-last_updated: Jun 12, 2026
+last_updated: Jun 15, 2026
 keywords: audit, logging, ai, foundation, tracking, compliance, ai interactions, monitoring, cost estimation, ai pricing
 template: howto-guide-template
 label: early-access
@@ -19,6 +19,8 @@ related:
 This document describes how to use audit logging with the AiFoundation module to track and audit AI interactions in your Spryker application.
 
 The audit logging feature provides comprehensive tracking of all AI interactions, including prompts, responses, token usage, inference time, and metadata. This enables monitoring, compliance, cost tracking, and debugging of AI operations.
+
+![AI Audit Logs cost estimator](https://spryker.s3.eu-central-1.amazonaws.com/docs/dg/dev/ai-commerce/cost-estimator.png)
 
 ## Back Office: Audit Logs page
 

--- a/docs/pbc/all/ai-commerce/latest/ai-commerce.md
+++ b/docs/pbc/all/ai-commerce/latest/ai-commerce.md
@@ -1,7 +1,7 @@
 ---
 title: AI Commerce
 description: AI Commerce brings AI-powered capabilities to your Spryker storefront, helping buyers find and order products faster with less manual effort.
-last_updated: Jun 08, 2026
+last_updated: Jun 15, 2026
 template: concept-topic-template
 ---
 
@@ -16,6 +16,14 @@ AI Commerce brings AI-powered capabilities to your Spryker storefront and back o
 | [Back Office Assistant](/docs/pbc/all/ai-commerce/latest/backoffice-assistant.html) | An AI-powered chat widget embedded in the Back Office. Admin users can ask natural language questions to navigate the Back Office, diagnose order issues, and create or update discounts.                                                                      |
 | [Search by Image](/docs/pbc/all/ai-commerce/latest/search-by-image.html)            | Lets customers upload a photo to search for products. AI analyzes the image, identifies a search term, and redirects to search results or the first matching product page.                                                                                     |
 | [Smart CMS Content Assistant](/docs/pbc/all/ai-commerce/latest/smart-cms-content-assistant.html) | An AI-powered panel in the Back Office CMS Page and CMS Block glossary editors. Back Office users can generate and refine placeholder content per locale through a conversational AI interface. |
+
+![Smart CMS Content Assistant](https://spryker.s3.eu-central-1.amazonaws.com/docs/dg/dev/ai-commerce/smart-cms.png)
+
+## Configure AI providers
+
+All AI Commerce features are provider-agnostic. You can configure OpenAI, AWS Bedrock, or Anthropic independently per feature — swapping the underlying model without changing application code. For instructions, see [Configure multiple AI providers for AI Commerce](/docs/dg/dev/ai/ai-commerce/configure-multiple-ai-providers.html).
+
+![Configure multiple AI providers](https://spryker.s3.eu-central-1.amazonaws.com/docs/dg/dev/ai-commerce/multiple-provider.png)
 
 ## Who benefits
 

--- a/docs/pbc/all/ai-commerce/latest/ai-commerce.md
+++ b/docs/pbc/all/ai-commerce/latest/ai-commerce.md
@@ -21,7 +21,7 @@ AI Commerce brings AI-powered capabilities to your Spryker storefront and back o
 
 ## Configure AI providers
 
-All AI Commerce features are provider-agnostic. You can configure OpenAI, AWS Bedrock, or Anthropic independently per feature — swapping the underlying model without changing application code. For instructions, see [Configure multiple AI providers for AI Commerce](/docs/dg/dev/ai/ai-commerce/configure-multiple-ai-providers.html).
+All AI Commerce features are provider-agnostic. You can configure OpenAI, AWS Bedrock, Anthropic, or any other supported provider independently per feature — swapping the underlying model without changing application code. For instructions, see [Configure multiple AI providers for AI Commerce](/docs/dg/dev/ai/ai-commerce/configure-multiple-ai-providers.html).
 
 ![Configure multiple AI providers](https://spryker.s3.eu-central-1.amazonaws.com/docs/dg/dev/ai-commerce/multiple-provider.png)
 

--- a/docs/pbc/all/ai-commerce/latest/smart-cms-content-assistant.md
+++ b/docs/pbc/all/ai-commerce/latest/smart-cms-content-assistant.md
@@ -1,11 +1,13 @@
 ---
 title: Smart CMS Content Assistant
 description: An AI-powered panel in the Back Office CMS Page and CMS Block glossary editors that generates and refines placeholder content per locale through a conversational interface.
-last_updated: Jun 08, 2026
+last_updated: Jun 15, 2026
 template: concept-topic-template
 ---
 
 Smart CMS Content Assistant is an AI-powered panel embedded in the Back Office CMS Page and CMS Block glossary editors. Back Office users can ask the AI to generate or refine the title and body content for each placeholder and locale, using the full entity context — including the page name, template, URL slug, SEO metadata, and assigned stores.
+
+![Smart CMS Content Assistant](https://spryker.s3.eu-central-1.amazonaws.com/docs/dg/dev/ai-commerce/smart-cms.png)
 
 ## Capabilities
 

--- a/docs/pbc/all/ai-foundation/latest/ai-foundation.md
+++ b/docs/pbc/all/ai-foundation/latest/ai-foundation.md
@@ -2,7 +2,7 @@
 title: AI Foundation
 description: Provider-agnostic AI connectivity layer for commerce
 template: concept-topic-template
-last_updated: Dec 12, 2025
+last_updated: Jun 15, 2026
 label: early-access
 related:
   - title: Install the AI Foundation module
@@ -19,6 +19,7 @@ You get a standardized, provider-agnostic way to build AI-powered commerce exper
 - Global cloud AI platforms such as **Azure OpenAI**, **AWS Bedrock**, and **Google Vertex AI / Gemini**
 - Frontier model providers such as **OpenAI** and **Anthropic Claude**
 - European sovereign AI providers such as **Mistral AI**
+- Any other provider, configurable per feature independently
 
 The goal is simple: make AI a first-class capability of your commerce platform, not a collection of isolated experiments.
 
@@ -114,6 +115,23 @@ AI Foundation is not a single feature. It is the base for many AI-enabled scenar
   Context-aware suggestions for catalog management, pricing, or data imports that make business users more productive, while keeping data in EU-based providers where required.
 
 Each of these use cases can evolve independently while still relying on the same AI Foundation underneath.
+
+---
+
+## Audit Logs and cost estimator
+
+AI Foundation includes built-in audit logging for every AI interaction. All prompts, responses, token usage, inference times, and statuses are captured automatically and are available in the Back Office at **Intelligence > Audit Logs**.
+
+The Audit Logs page provides:
+
+- **Summary statistics**: Total requests, tokens consumed, success rate, average inference time, and total estimated cost.
+- **Cost estimator**: Per-provider and per-model cost breakdown based on token prices you configure. Prices are entered in the Back Office per model and applied at display time, so changing a price immediately revalues all historical interactions.
+- **Filterable log table**: Filter by configuration name, status, conversation reference, and date range.
+- **Detail drawer**: View the full prompt, response, token breakdown, metadata, and error details for any interaction.
+
+![AI Audit Logs cost estimator](https://spryker.s3.eu-central-1.amazonaws.com/docs/dg/dev/ai-commerce/cost-estimator.png)
+
+For setup instructions, see [AI Foundation Audit Logs](/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.html).
 
 ---
 


### PR DESCRIPTION
## Summary

- **`ai-foundation-audit-logs.md`**: Added cost estimator screenshot after the intro paragraph.
- **`pbc/all/ai-commerce/latest/ai-commerce.md`**: Added Smart CMS screenshot after the features table and a new "Configure AI providers" section with the multiple-provider screenshot and a link to the configure guide.
- **`configure-multiple-ai-providers.md`**: Added multiple-provider screenshot after the intro paragraph.

## Test plan

- [x] Verify images render correctly on the docs site
- [x] Verify internal link to `configure-multiple-ai-providers.html` resolves correctly
- [x] Confirm no vale or markdownlint errors (validated locally — 0 errors)