### PR TITLE
CC-39249: Document typed nested objects, object collections, and validation lifting in API Platform resource schemas

### DIFF
--- a/_data/sidebars/dg_dev_sidebar.yml
+++ b/_data/sidebars/dg_dev_sidebar.yml
@@ -892,6 +892,8 @@ entries:
       url: /docs/dg/dev/upgrade-and-migrate/migrate-to-api-platform.html
     - title: API Platform migration overview
       url: /docs/dg/dev/upgrade-and-migrate/migrate-to-api-platform-overview.html
+    - title: Upgrade API Platform resources to typed nested objects
+      url: /docs/dg/dev/upgrade-and-migrate/upgrade-to-api-platform-typed-nested-objects.html
     - title: Migrate from Auth to SecurityGui module
       url: /docs/dg/dev/upgrade-and-migrate/migrate-from-auth-to-securitygui-module.html
     - title: Migrating from Twig v1 to Twig v3

--- a/docs/dg/dev/architecture/api-platform/resource-schemas.md
+++ b/docs/dg/dev/architecture/api-platform/resource-schemas.md
@@ -547,12 +547,12 @@ The merge rules across contributors:
 
 ##### `allowMissingFields`
 
-A `Collection` with `allowMissingFields: true` (e.g. a checkout `billingAddress` referenced only by
-id) tolerates absent keys. On a value object an absent field denormalizes to `null`, so the
+A `Collection` with `allowMissingFields: true` (for example, a checkout `billingAddress` referenced
+only by id) tolerates absent keys. On a value object an absent field denormalizes to `null`, so the
 generator relaxes presence constraints when lifting: each `NotBlank` gains `allowNull: true` and
 each `NotNull` is dropped — an absent field passes, a present-but-empty one still fails. When two
 contributors disagree for the same field and group, the **relaxed** `NotBlank` supersedes the strict
-one, so the lenient (e.g. address-by-id) context is not rejected.
+one, so the lenient (for example, address-by-id) context is not rejected.
 
 #### When to use `objectName`
 

--- a/docs/dg/dev/architecture/api-platform/resource-schemas.md
+++ b/docs/dg/dev/architecture/api-platform/resource-schemas.md
@@ -1,7 +1,7 @@
 ---
 title: Resource Schemas
 description: Understanding API Platform resource schema definitions in Spryker.
-last_updated: Jun 26, 2026
+last_updated: Jul 13, 2026
 template: concept-topic-template
 related:
   - title: API Platform
@@ -343,7 +343,7 @@ to a real class whose shape is enforced by PHP's type system.
 ### Why use it
 
 - **Type safety in PHP.** The parent property is typed to the generated class (for example,
-  `?CartsTotalsStorefrontResource`) instead of `array`, so providers and processors get IDE
+  `?CartsTotalsStorefrontObject`) instead of `array`, so providers and processors get IDE
   autocompletion and the language enforces the field set.
 - **Precise OpenAPI schema.** Each sub-field carries its own `type`, `description`, and `example`,
   so the OpenAPI document and Swagger UI render the object as a named component schema instead of
@@ -395,19 +395,21 @@ For a `Carts` resource with the `totals` property above, the generator:
 1. Types the property on the resource class:
 
    ```php
-   public ?CartsTotalsStorefrontResource $totals = null;
+   public ?CartsTotalsStorefrontObject $totals = null;
    ```
 
-2. Writes a companion class next to the resource in the `Generated\Api\{ApiType}\` namespace. The
-   class is `final`, carries **no** `#[ApiResource]` attribute — it is an embedded value object,
-   not a routed resource — and exposes the typed sub-fields plus their accessors:
+2. Writes a companion class in the `Generated\Api\{ApiType}\{ResourceName}\` namespace (a
+   sub-namespace named after the owning resource, alongside the resource class in
+   `Generated\Api\{ApiType}\`). The class is `final`, carries **no** `#[ApiResource]` attribute —
+   it is an embedded value object, not a routed resource — and exposes the typed sub-fields plus
+   their accessors:
 
    ```php
-   namespace Generated\Api\Storefront;
+   namespace Generated\Api\Storefront\Carts;
 
    use ApiPlatform\Metadata\ApiProperty;
 
-   final class CartsTotalsStorefrontResource
+   final class CartsTotalsStorefrontObject
    {
        #[ApiProperty(description: 'Items × prices before any discount/tax.', openapiContext: ['example' => 16058])]
        public ?int $subtotal = null;
@@ -422,10 +424,12 @@ For a `Carts` resource with the `totals` property above, the generator:
    }
    ```
 
-The companion class name is `{ResourceName}{PropertyPath}{ApiType}Resource` — the resource's
-normalized name, the capitalized property path, the API type, and the `Resource` suffix. So
-`Carts` + `totals` on the storefront API becomes `CartsTotalsStorefrontResource`; a checkout
-`billingAddress` becomes `CheckoutBillingAddressStorefrontResource`.
+The companion class name is `{ResourceName}{PropertyPath}{ApiType}Object` — the resource's
+normalized name, the capitalized property path, the API type, and the `Object` suffix (contrast
+the routed resource class itself, which keeps the `Resource` suffix). It lives in the
+`Generated\Api\{ApiType}\{ResourceName}` sub-namespace. So `Carts` + `totals` on the storefront API
+becomes `Generated\Api\Storefront\Carts\CartsTotalsStorefrontObject`; a checkout `billingAddress`
+becomes `Generated\Api\Storefront\Checkout\CheckoutBillingAddressStorefrontObject`.
 
 {% info_block infoBox "Imports in companion classes" %}
 
@@ -454,17 +458,18 @@ totals:
                     openapiContext: { example: 1457 }
 ```
 
-on the storefront `Carts` resource generates a `CartsTotalsStorefrontResource` class with
-`public ?CartsTotalsTaxStorefrontResource $tax = null;`, plus a separate
-`CartsTotalsTaxStorefrontResource` class with `public ?int $amount = null;`. A deeper path simply
-keeps concatenating — an agent quote-request resource's `shownVersion.cartTotals` object becomes
-`AgentQuoteRequestsShownVersionCartTotalsStorefrontResource`.
+on the storefront `Carts` resource generates a `CartsTotalsStorefrontObject` class with
+`public ?CartsTotalsTaxStorefrontObject $tax = null;`, plus a separate
+`CartsTotalsTaxStorefrontObject` class with `public ?int $amount = null;` (both in the
+`Generated\Api\Storefront\Carts` namespace). A deeper path simply keeps concatenating — an agent
+quote-request resource's `shownVersion.cartTotals` object becomes
+`AgentQuoteRequestsShownVersionCartTotalsStorefrontObject`.
 
 ### Object collections
 
 A `type: array` property whose `items:` are themselves a typed object (`type: object` with nested
 `properties:`) generates a value-object class for the element type. The class is named after the
-**pluralized** field segment — `{ResourceName}{PluralField}{ApiType}Resource` — and the parent
+**pluralized** field segment — `{ResourceName}{PluralField}{ApiType}Object` — and the parent
 property stays a PHP `array` carrying a `@var array<…>` docblock so the serializer denormalizes
 each element into the generated class:
 
@@ -479,9 +484,9 @@ customer:
             email:     { type: string }
 ```
 
-On the storefront `Carts` resource this generates `CartsCustomersStorefrontResource` (the field
+On the storefront `Carts` resource this generates `CartsCustomersStorefrontObject` (the field
 `customer` pluralized to `Customers`) as the element type, and types the property as
-`array<\Generated\Api\Storefront\CartsCustomersStorefrontResource>`.
+`array<\Generated\Api\Storefront\Carts\CartsCustomersStorefrontObject>`.
 
 ### Per-resource validation lifting
 
@@ -558,9 +563,43 @@ resource:
 ```
 
 The merged `calculations` object carries **both** `discountTotal` and `productOptionTotal`, and a
-single `CartItemsCalculationsStorefrontResource` value object is generated for it. This deep merge —
+single `CartItemsCalculationsStorefrontObject` value object is generated for it. This deep merge —
 not a shared class — is how identically-named objects accumulate fields across modules while each
 resource keeps its own independent request/response shape.
+
+#### Conflicting shapes fail generation
+
+Deep merge only applies when the contributors agree on the shape. When one contributor declares a
+property as a typed object (`type: object` with `properties`) or an object collection (`type: array`
+with `items.properties`) and another declares the **same** property as something structurally
+different — a `map`, a scalar, a plain array, or an object without `properties` — a silent
+last-wins merge would drop either the typed value object or the plain field. Instead, generation
+**fails with an error** that names the property and both contributing source files:
+
+```text
+Conflicting shapes for property "calculations": .../DiscountsRestApi/.../cart-items.resource.yml
+declares it as a typed object (`type: object` with `properties`), but
+.../project/.../cart-items.resource.yml declares it as `type: map`. ...
+```
+
+This applies both within a layer and across layers (project overrides feature overrides core). The
+usual cause is a project fragment that still declares a property as `type: map`/`array` while a core
+module has since promoted it to a typed object — convert the project fragment to the typed form.
+Same-shape overrides (object + object, collection + collection) still deep-merge, and attribute-only
+overrides (an override that sets, for example, `writable: false` without re-declaring `type`) merge
+as before.
+
+If you deliberately intend to re-shape an inherited property — for example, collapse a core typed
+object back into a `map`, or replace it wholesale rather than extend it — set `replace: true` on the
+overriding declaration. It takes your declaration wholesale (the inherited one is discarded),
+suppresses the conflict guard, and is stripped from the generated output:
+
+```yaml
+# project cart-items.resource.yml — deliberately override the core shape
+calculations:
+    type: map
+    replace: true
+```
 
 ## Project-defined canonical nested objects
 
@@ -716,7 +755,7 @@ activates and:
 {% info_block infoBox "Shared class versus per-resource class" %}
 
 Without `objectName`, each `type: object` property generates its own per-resource value-object
-class (for example, `CheckoutBillingAddressStorefrontResource`). With `objectName: Address`, all
+class (for example, `CheckoutBillingAddressStorefrontObject`). With `objectName: Address`, all
 matching properties across all resources instead share the single `Generated\Api\Storefront\Address`
 class. Use a canonical object when several resources genuinely share one shape and you want them to
 stay in lockstep; keep the inline form when each resource's shape is independent.

--- a/docs/dg/dev/architecture/api-platform/resource-schemas.md
+++ b/docs/dg/dev/architecture/api-platform/resource-schemas.md
@@ -1,7 +1,7 @@
 ---
 title: Resource Schemas
 description: Understanding API Platform resource schema definitions in Spryker.
-last_updated: Jun 25, 2026
+last_updated: Jun 26, 2026
 template: concept-topic-template
 related:
   - title: API Platform
@@ -257,7 +257,7 @@ resource:
 | `number` | `float` | `3.14` | Decimal numbers |
 | `boolean` | `bool` | `true` | True/false values |
 | `array` | `array` | `["a", "b"]` | Lists of values |
-| `object` | `object` | `{"key": "value"}` | Strictly typed nested objects — generates a typed companion class. See [Typed nested objects](#typed-nested-objects). |
+| `object` | `object` | `{"key": "value"}` | Strictly typed nested objects — generates a typed companion class. See [Typed nested objects](#typed-nested-objects). A project can also share one shape across resources with a [canonical nested object](#project-defined-canonical-nested-objects). |
 | `map` | `array` | `{"key": "value"}` | Free-shape associative payloads documented via `openapiContext`. Stored as PHP `array` and rendered as `type: object` in the OpenAPI specification. |
 | `mixed` | `mixed` | any | Use only when the payload genuinely has no fixed shape and cannot be described via `openapiContext`. |
 
@@ -559,6 +559,201 @@ The merged `calculations` object carries **both** `discountTotal` and `productOp
 single `CartItemsCalculationsStorefrontResource` value object is generated for it. This deep merge —
 not a shared class — is how identically-named objects accumulate fields across modules while each
 resource keeps its own independent request/response shape.
+
+## Project-defined canonical nested objects
+
+[Typed nested objects](#typed-nested-objects) generate one value-object class **per resource
+property**: a `billingAddress` on the checkout resource and a `shippingAddress` on the order
+resource each get their own independent class, even when both describe the same real-world shape.
+That keeps each resource self-contained, but it also means the same address shape is authored and
+maintained in several places.
+
+A **canonical nested object** lets a project define that shared shape **once** and have it flow
+into every resource property that opts in. All the opting-in properties then collapse onto a single
+generated class — `Generated\Api\{ApiType}\{Object}` (for example, `Generated\Api\Storefront\Address`) —
+instead of a per-resource companion class.
+
+This is a pure project opt-in. With no canonical object files present, generation is byte-for-byte
+identical to the default per-resource behavior described above — nothing changes until a project
+adds its first `*.object.yml`.
+
+### File location and naming
+
+Canonical objects live in a **dedicated, reserved subdirectory literally named `objects/`** inside the per-`apiType` resource directory. The directory name is always `objects` — it is never named after a resource or module. This is distinct from resource definition files, which live directly in the `apiType` directory:
+
+```text
+resources/api/storefront/
+├── checkout.resource.yml          # a resource definition
+├── checkout.validation.yml        # its validation
+└── objects/                       # reserved dir — canonical objects only
+    ├── address.object.yml
+    └── address.object.validation.yml
+```
+
+Only `*.object.yml` and `*.object.validation.yml` files belong in `objects/`. Resource files (`*.resource.yml`) are placed directly in the per-`apiType` directory, never inside `objects/`.
+
+The `<dashed-name>.<kind>.yml` naming pattern is the same for both file types — only the kind word differs. `address.object.yml` is the canonical-object analog of `checkout.resource.yml`, and `address.object.validation.yml` is the analog of `checkout.validation.yml`. The `object` versus `resource` word identifies the artifact kind, not a different naming scheme.
+
+Full path patterns:
+
+```text
+resources/api/<apiType>/objects/<dashed-name>.object.yml
+resources/api/<apiType>/objects/<dashed-name>.object.validation.yml   # optional, see Validation
+```
+
+For example, on the storefront API:
+
+```text
+src/Pyz/resources/api/storefront/objects/address.object.yml
+src/Pyz/resources/api/storefront/objects/address.object.validation.yml
+```
+
+The file name uses a dashed (kebab-case) object name, while `object.name` **inside** the file is
+CamelCase. The CamelCase `object.name` is the contract: it must exactly match the `objectName:`
+join tag declared on the resource properties that want this shape (see [The `objectName` join
+tag](#the-objectname-join-tag)).
+
+### Central directory
+
+A project may keep canonical object files in one central location instead of (or in addition to) the per-module `objects/` directories. Both locations are scanned simultaneously.
+
+Configure the central directory via the Symfony bundle config node `spryker_api_platform.canonical_object_search_directories`, keyed by API type. Relative paths resolve against the project root; `%kernel.project_dir%` is also supported:
+
+```yaml
+# config/packages/spryker_api_platform.yaml
+spryker_api_platform:
+    canonical_object_search_directories:
+        storefront:
+            - '%kernel.project_dir%/config/api/objects/storefront'
+```
+
+The same `*.object.yml` / `*.object.validation.yml` naming rules apply. Files in a central directory are always treated as the **project** layer, so they participate in the standard `project > feature > core` merge precedence.
+
+Defining the same `objectName` more than once within the same layer — for example, one module file and one central-directory file both at project layer — is a fail-loud error: generation aborts with an `ApiSchemaGenerationException` naming both source files. The same name across different layers is fine — that is the normal override.
+
+### File format
+
+The file contains a single top-level `object:` key:
+
+```yaml
+# address.object.yml
+object:
+    name: Address                                   # CamelCase; matches `objectName: Address` on resource properties
+    properties:
+        salutation: { type: string, description: 'Address salutation.', example: 'Mr' }
+        firstName:  { type: string, description: 'First name.', example: 'Jane' }
+        lastName:   { type: string, description: 'Last name.', example: 'Doe' }
+        address1:   { type: string, description: 'Street name.', example: 'Julie-Wolfthorn-Straße' }
+        zipCode:    { type: string, description: 'ZIP / postal code.', example: '10115' }
+        city:       { type: string, description: 'City.', example: 'Berlin' }
+```
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `object.name` | string | Yes | CamelCase object name. Matched against `objectName:` join tag on every resource property that references this object. |
+| `object.properties` | map | Yes | Field definitions. Each field uses the **same syntax as a resource property** — `type`, `description`, `validation`, `example`, and so on. |
+| `object.extends` | string | No | CamelCase name of another canonical object whose resolved fields are inherited first. See [Composition](#composition-with-extends-and-omit). |
+| `object.omit` | string[] | No | Names of inherited fields to drop from the `extends` base before this object's own properties are applied. |
+
+### Composition with `extends` and `omit`
+
+An object can inherit another canonical object's fields with `extends`, then trim and extend them.
+This avoids re-declaring a shared shape when one variant is a near-copy of another — for example, a
+read-only address snapshot derived from a writable address:
+
+```yaml
+# address-snapshot.object.yml
+object:
+    name: AddressSnapshot
+    extends: Address                                # inherit all Address fields first
+    omit: [id, idCompanyBusinessUnitAddress]        # drop the write-only identifiers
+    properties:
+        country: { type: string, description: 'Country name.', example: 'Germany' }   # add a read-only field
+```
+
+Fields resolve in this order, with later steps winning:
+
+1. The fields inherited from `extends`.
+2. Any field named in `omit` is removed.
+3. This object's own `properties` are applied — a field redeclared here overrides the inherited one.
+
+An `extends` cycle (for example, two objects that extend each other) is rejected at generation time
+with an `ApiSchemaGenerationException`.
+
+### The `objectName` join tag
+
+A resource property opts into a canonical object by declaring `type: object` together with an
+`objectName:` tag whose value equals the canonical `object.name`:
+
+```yaml
+# checkout.resource.yml
+properties:
+    billingAddress:
+        type: object
+        objectName: Address       # joins this property to the canonical Address object
+        readable: false
+        writable: true
+        properties:
+            zipCode: { type: string }
+```
+
+The `objectName` tag is dormant on its own: if no `address.object.yml` exists, the property's
+inline `properties:` block is generated exactly as a normal [typed nested
+object](#typed-nested-objects). When a canonical file for `Address` **is** present, the tag
+activates and:
+
+- The property's inline `properties:` are **replaced** by the canonical object's resolved shape.
+- The mount attributes — `readable`, `writable`, `required`, `nullable` — stay on the referencing
+  property. They describe how this property is mounted on this resource and are **not** owned by
+  the canonical object, so the same canonical shape can be writable on one resource and read-only
+  on another.
+- A single shared `Generated\Api\{ApiType}\{Object}` class is emitted for the canonical object. No
+  per-property companion class is generated for that property; every property tagged with the same
+  `objectName` is typed to the one shared class.
+
+{% info_block infoBox "Shared class versus per-resource class" %}
+
+Without `objectName`, each `type: object` property generates its own per-resource value-object
+class (for example, `CheckoutBillingAddressStorefrontResource`). With `objectName: Address`, all
+matching properties across all resources instead share the single `Generated\Api\Storefront\Address`
+class. Use a canonical object when several resources genuinely share one shape and you want them to
+stay in lockstep; keep the inline form when each resource's shape is independent.
+
+{% endinfo_block %}
+
+### Validation
+
+Field-level validation for a canonical object is authored in a parallel
+`<dashed-name>.object.validation.yml` file, using the same format as a resource
+[validation schema](/docs/dg/dev/architecture/api-platform/validation-schemas.html):
+
+```yaml
+# address.object.validation.yml
+zipCode:
+    - NotBlank: { message: 'ZIP code is required.' }
+firstName:
+    - NotBlank: { message: 'First name is required.' }
+```
+
+These constraints are lifted onto the generated canonical class. Every resource property that
+references the object through `objectName` then carries an `Assert\Valid` cascade to that class, so
+the canonical field rules are enforced wherever the object is used — you author the object's
+validation once, in one place.
+
+### Layer precedence
+
+Canonical objects follow the same layer rules as resource schemas. The layer is detected from the
+file path — a `/Pyz/` path is a project file, a `/SprykerFeature/` path is a feature file, and
+anything else is core. Same-named objects merge by `object.name` with the precedence:
+
+```text
+project > feature > core
+```
+
+Because the merge is by `objectName`, a project can add a single field to a feature-layer canonical
+object without redefining the whole object. Core ships no canonical object files today; the
+mechanism is available to the project, feature, and core layers, and in practice projects are the
+primary users.
 
 ## Documenting nested properties for OpenAPI and Swagger UI
 

--- a/docs/dg/dev/architecture/api-platform/resource-schemas.md
+++ b/docs/dg/dev/architecture/api-platform/resource-schemas.md
@@ -1,7 +1,7 @@
 ---
 title: Resource Schemas
 description: Understanding API Platform resource schema definitions in Spryker.
-last_updated: Jun 3, 2026
+last_updated: Jun 16, 2026
 template: concept-topic-template
 related:
   - title: API Platform
@@ -257,17 +257,21 @@ resource:
 | `number` | `float` | `3.14` | Decimal numbers |
 | `boolean` | `bool` | `true` | True/false values |
 | `array` | `array` | `["a", "b"]` | Lists of values |
-| `object` | `object` | `{"key": "value"}` | Strictly typed nested objects |
+| `object` | `object` | `{"key": "value"}` | Strictly typed nested objects — generates a typed companion class. See [Typed nested objects](#typed-nested-objects). |
 | `map` | `array` | `{"key": "value"}` | Free-shape associative payloads documented via `openapiContext`. Stored as PHP `array` and rendered as `type: object` in the OpenAPI specification. |
 | `mixed` | `mixed` | any | Use only when the payload genuinely has no fixed shape and cannot be described via `openapiContext`. |
 
 Use `map` when the payload is a structured JSON object whose schema you want to describe via
 `openapiContext` rather than a strongly typed PHP class. This is the recommended type whenever a
-request or response body is a JSON object with a known shape but no dedicated DTO class — it
+request or response body is a JSON object with a known shape but no dedicated class — it
 keeps the property typed as a simple `array` in PHP while still producing rich OpenAPI metadata
 and a working "Try Out" body in Swagger UI. See
 [Documenting nested properties for OpenAPI and Swagger UI](#documenting-nested-properties-for-openapi-and-swagger-ui)
 for the full pattern.
+
+When you do want a strongly typed class for the payload — so PHP enforces the field set and the
+OpenAPI document publishes a named component schema — use `type: object` with nested
+`properties:` instead. See [Typed nested objects](#typed-nested-objects).
 
 ### Property attributes
 
@@ -322,6 +326,132 @@ isActive:
   type: boolean
   default: true     # Defaults to true if not provided
 ```
+
+## Typed nested objects
+
+A property declared as `type: object` with its own nested `properties:` block generates a
+dedicated, strongly typed companion class — not an untyped array. The generator emits one PHP
+class per nested object, types the parent property to that class, and publishes a full
+field-by-field schema in the OpenAPI document. The serializer hydrates the nested object from the
+same JSON payload, so the response on the wire is identical to the array-based form it replaces.
+
+This is the strongly typed counterpart to the `map` pattern described in
+[Documenting nested properties for OpenAPI and Swagger UI](#documenting-nested-properties-for-openapi-and-swagger-ui):
+`map` documents a nested object while keeping it a plain PHP `array`; `type: object` promotes it
+to a real class whose shape is enforced by PHP's type system.
+
+### Why use it
+
+- **Type safety in PHP.** The parent property is typed to the generated class (for example,
+  `?CartsTotals`) instead of `array`, so providers and processors get IDE autocompletion and the
+  language enforces the field set.
+- **Precise OpenAPI schema.** Each sub-field carries its own `type`, `description`, and `example`,
+  so the OpenAPI document and Swagger UI render the object as a named component schema instead of
+  an opaque `object`.
+- **No runtime contract change.** Because the serializer denormalizes the typed object from the
+  same keys, migrating a property from `array`/`map` to `type: object` leaves the JSON response
+  unchanged — only the generated PHP and the published schema improve.
+
+### When to use which type
+
+| Use | When |
+|-----|------|
+| `type: object` (with `properties`) | The payload has a **stable, known shape** you want enforced as a PHP class — for example, cart and order `totals`, or a quote-request `customer`. |
+| `type: map` (with `openapiContext`) | The shape is known and worth documenting, but you do **not** want a dedicated PHP class — for example, payloads aggregated from several transfer objects, or PSP-specific responses. See [Documenting nested properties for OpenAPI and Swagger UI](#documenting-nested-properties-for-openapi-and-swagger-ui). |
+| `type: mixed` | The payload genuinely has **no fixed shape** and cannot be described via `openapiContext`. |
+
+### How to declare it
+
+Give the property `type: object` and nest its fields under `properties:`. Sub-fields accept the
+same attributes as top-level properties (`type`, `description`, `openapiContext`, `nullable`,
+`serializedName`, `serializedPath`):
+
+```yaml
+totals:
+    type: object
+    readable: true
+    writable: false
+    required: false
+    description: 'Calculated cart totals in cents.'
+    properties:
+        subtotal:
+            type: integer
+            description: 'Items × prices before any discount/tax.'
+            openapiContext: { example: 16058 }
+        grandTotal:
+            type: integer
+            description: 'What the customer pays.'
+            openapiContext: { example: 14601 }
+        priceToPay:
+            type: integer
+            description: 'Grand total adjusted for any pre-paid amount (e.g. gift cards).'
+            openapiContext: { example: 14601 }
+```
+
+### Generated output
+
+For a `Carts` resource with the `totals` property above, the generator:
+
+1. Types the property on the resource class:
+
+   ```php
+   public ?CartsTotals $totals = null;
+   ```
+
+2. Writes a companion class next to the resource in the `Generated\Api\{ApiType}\` namespace. The
+   class is `final`, carries **no** `#[ApiResource]` attribute — it is an embedded value object,
+   not a routed resource — and exposes the typed sub-fields plus their accessors:
+
+   ```php
+   namespace Generated\Api\Storefront;
+
+   use ApiPlatform\Metadata\ApiProperty;
+
+   final class CartsTotals
+   {
+       #[ApiProperty(description: 'Items × prices before any discount/tax.', openapiContext: ['example' => 16058])]
+       public ?int $subtotal = null;
+
+       #[ApiProperty(description: 'What the customer pays.', openapiContext: ['example' => 14601])]
+       public ?int $grandTotal = null;
+
+       #[ApiProperty(description: 'Grand total adjusted for any pre-paid amount (e.g. gift cards).', openapiContext: ['example' => 14601])]
+       public ?int $priceToPay = null;
+
+       // Getters, setters, toArray(), fromArray() …
+   }
+   ```
+
+The companion class name is `{ResourceName}{PropertyName}` in PascalCase — so `Carts` + `totals`
+becomes `CartsTotals`.
+
+{% info_block infoBox "Imports in companion classes" %}
+
+Companion classes import only the attributes they actually use (`ApiProperty`, `SerializedName`,
+`SerializedPath`). An attribute referenced without its `use` statement would resolve to a
+non-existent class in the `Generated` namespace and break attribute reflection at runtime, so the
+generator never emits an unused import.
+
+{% endinfo_block %}
+
+### Nested objects within objects
+
+Objects can nest to any depth. Each level generates its own class, named by appending the child
+property to its parent's class name. For example:
+
+```yaml
+totals:
+    type: object
+    properties:
+        tax:
+            type: object
+            properties:
+                amount:
+                    type: integer
+```
+
+generates a `CartsTotals` class with `public ?CartsTotalsTax $tax = null;`, plus a separate
+`CartsTotalsTax` class with `public ?int $amount = null;`.
 
 ## Documenting nested properties for OpenAPI and Swagger UI
 

--- a/docs/dg/dev/architecture/api-platform/resource-schemas.md
+++ b/docs/dg/dev/architecture/api-platform/resource-schemas.md
@@ -1,7 +1,7 @@
 ---
 title: Resource Schemas
 description: Understanding API Platform resource schema definitions in Spryker.
-last_updated: Jun 16, 2026
+last_updated: Jun 25, 2026
 template: concept-topic-template
 related:
   - title: API Platform
@@ -343,8 +343,8 @@ to a real class whose shape is enforced by PHP's type system.
 ### Why use it
 
 - **Type safety in PHP.** The parent property is typed to the generated class (for example,
-  `?CartsTotals`) instead of `array`, so providers and processors get IDE autocompletion and the
-  language enforces the field set.
+  `?CartsTotalsStorefrontResource`) instead of `array`, so providers and processors get IDE
+  autocompletion and the language enforces the field set.
 - **Precise OpenAPI schema.** Each sub-field carries its own `type`, `description`, and `example`,
   so the OpenAPI document and Swagger UI render the object as a named component schema instead of
   an opaque `object`.
@@ -395,7 +395,7 @@ For a `Carts` resource with the `totals` property above, the generator:
 1. Types the property on the resource class:
 
    ```php
-   public ?CartsTotals $totals = null;
+   public ?CartsTotalsStorefrontResource $totals = null;
    ```
 
 2. Writes a companion class next to the resource in the `Generated\Api\{ApiType}\` namespace. The
@@ -407,7 +407,7 @@ For a `Carts` resource with the `totals` property above, the generator:
 
    use ApiPlatform\Metadata\ApiProperty;
 
-   final class CartsTotals
+   final class CartsTotalsStorefrontResource
    {
        #[ApiProperty(description: 'Items × prices before any discount/tax.', openapiContext: ['example' => 16058])]
        public ?int $subtotal = null;
@@ -422,8 +422,10 @@ For a `Carts` resource with the `totals` property above, the generator:
    }
    ```
 
-The companion class name is `{ResourceName}{PropertyName}` in PascalCase — so `Carts` + `totals`
-becomes `CartsTotals`.
+The companion class name is `{ResourceName}{PropertyPath}{ApiType}Resource` — the resource's
+normalized name, the capitalized property path, the API type, and the `Resource` suffix. So
+`Carts` + `totals` on the storefront API becomes `CartsTotalsStorefrontResource`; a checkout
+`billingAddress` becomes `CheckoutBillingAddressStorefrontResource`.
 
 {% info_block infoBox "Imports in companion classes" %}
 
@@ -436,8 +438,8 @@ generator never emits an unused import.
 
 ### Nested objects within objects
 
-Objects can nest to any depth. Each level generates its own class, named by appending the child
-property to its parent's class name. For example:
+Objects can nest to any depth. Each level generates its own class, named by concatenating the
+property path onto the resource name. For example:
 
 ```yaml
 totals:
@@ -450,75 +452,47 @@ totals:
                     type: integer
 ```
 
-generates a `CartsTotals` class with `public ?CartsTotalsTax $tax = null;`, plus a separate
-`CartsTotalsTax` class with `public ?int $amount = null;`.
+on the storefront `Carts` resource generates a `CartsTotalsStorefrontResource` class with
+`public ?CartsTotalsTaxStorefrontResource $tax = null;`, plus a separate
+`CartsTotalsTaxStorefrontResource` class with `public ?int $amount = null;`. A deeper path simply
+keeps concatenating — an agent quote-request resource's `shownVersion.cartTotals` object becomes
+`AgentQuoteRequestsShownVersionCartTotalsStorefrontResource`.
 
-### Shared canonical objects
+### Object collections
 
-By default a typed nested object generates a **per-resource** class (`CartsTotals`,
-`OrdersTotals`, …). Many resources carry the same conceptual object — pagination metadata, money
-totals, addresses, customer summaries — and generating a separate class for each is wasteful.
-
-Add `objectName` to a `type: object` property to share **one canonical class** across resources:
+A `type: array` property whose `items:` are themselves a typed object (`type: object` with nested
+`properties:`) generates a value-object class for the element type. The class is named after the
+**pluralized** field segment — `{ResourceName}{PluralField}{ApiType}Resource` — and the parent
+property stays a PHP `array` carrying a `@var array<…>` docblock so the serializer denormalizes
+each element into the generated class:
 
 ```yaml
-# carts.resource.yml
-totals:
-    type: object
-    objectName: Totals
-    properties:
-        subtotal:   { type: integer, openapiContext: { example: 16058 } }
-        grandTotal: { type: integer, openapiContext: { example: 14601 } }
-        priceToPay: { type: integer, openapiContext: { example: 14601 } }
-
-# orders.resource.yml
-totals:
-    type: object
-    objectName: Totals
-    properties:
-        subtotal:          { type: integer, openapiContext: { example: 9902 } }
-        grandTotal:        { type: integer, openapiContext: { example: 10392 } }
-        canceledTotal:     { type: integer, openapiContext: { example: 0 } }
-        remunerationTotal: { type: integer, openapiContext: { example: 0 } }
+# carts.resource.yml — a list of typed customer objects
+customer:
+    type: array
+    items:
+        type: object
+        properties:
+            firstName: { type: string }
+            email:     { type: string }
 ```
 
-Both properties are typed `?Totals`, and a single `Generated\Api\{ApiType}\Totals` class is
-generated whose fields are the **union** of every contribution (the *canonical superset* — here
-`subtotal`, `grandTotal`, `priceToPay`, `canceledTotal`, `remunerationTotal`, …). A resource
-references the canonical class even if it never populates some of the fields.
+On the storefront `Carts` resource this generates `CartsCustomersStorefrontResource` (the field
+`customer` pluralized to `Customers`) as the element type, and types the property as
+`array<\Generated\Api\Storefront\CartsCustomersStorefrontResource>`.
 
-`objectName` supports three forms:
+### Per-resource validation lifting
 
-| Declaration | Effect |
-|-------------|--------|
-| `type: object` + `objectName: X` + `properties:` | Contributes its fields to canonical object `X`; property typed `?X`. |
-| `type: object` + `objectName: X` (no `properties:`) | Pure reference — typed `?X`, contributes nothing. |
-| `type: object` + `properties:` (no `objectName`) | Per-resource class `{Resource}{Property}` (the default described above). |
+Each typed nested object gets its **own** value-object class, so validation you authored the
+array-shaped way — an `Assert\Collection` on the object property in the resource's
+`{resource-name}.validation.yml` — would reject the denormalized object value with a 422
+(`This value should be of type array`). The generator resolves this automatically: for a writable
+object property it **lifts** the `Collection.fields` constraints off the property and onto the
+matching fields of that resource's value object, and emits a plain `#[Assert\Valid]` cascade
+(carrying the operation groups) on the property instead of the `Collection`.
 
-#### Conflict policy
-
-Because a canonical object's fields arrive from many files, the generator applies a deterministic
-merge:
-
-- A field declared by multiple contributions **must have the same `type`** — a mismatch is a
-  hard generation error naming the contributing files.
-- For `description`, `openapiContext`, and `nullable`, the **first contribution wins** (resources
-  are processed in a stable, path-sorted order), so the generated schema is reproducible.
-- Validation constraints are the exception to first-wins: they are **unioned** across all
-  contributors (see [Validation on canonical objects](#validation-on-canonical-objects) below).
-- An `objectName` that is referenced but never receives a `properties` contribution is a hard
-  error, as is a canonical name that collides with a generated resource class.
-
-#### Validation on canonical objects
-
-A canonical object property denormalizes the incoming JSON into a typed value object, not an array.
-A field validation written the array-shaped way — an `Assert\Collection` on the property in the
-resource's `{resource-name}.validation.yml` — would therefore reject the object value with a 422
-(`This value should be of type array`). The generator resolves this automatically: it **lifts** the
-`Collection.fields` constraints off the property and onto the matching fields of the canonical value
-object, and emits a plain `#[Assert\Valid]` cascade on the property instead of the `Collection`.
-
-You keep authoring validation exactly as before — write the `Collection` against the object property:
+You keep authoring validation exactly as before — write the `Collection` against the object
+property:
 
 ```yaml
 # checkout-data.validation.yml
@@ -534,32 +508,57 @@ post:
                                 - Email:    { message: 'Email is invalid.' }
 ```
 
-The merge rules across contributors:
+The lifted constraints are re-grouped through the resource's own operation groups (so this
+`checkout-data` `customer.email` rule stays in the `checkout-data:create` group) and attached to
+the value object's `email` field; the `customer` property itself carries only `#[Assert\Valid]`.
+Each resource's value object is validated independently — there is **no** cross-resource union,
+because every resource has its own value-object class. A property whose object is not writable, or
+a plain list property that is not a typed object collection, keeps its array-shaped `Collection` —
+only writable typed-object properties are lifted.
 
-- **Per-resource grouping.** Each lifted constraint is re-grouped through the contributing
-  resource's operation groups, so a `customer.email` rule from checkout stays in the
-  `checkout:create` group and does not leak onto other resources sharing the `Customer` object.
-- **Union + dedup.** A field's constraints are unioned across every contributing resource and
-  deduplicated, so the canonical value object carries the superset of all contributors' rules.
-- **Array properties keep `Collection`.** A property with `type: object` *without* `objectName`
-  (or a list property like `payments` / `shipments`) is still validated by its array-shaped
-  `Collection` — only canonical-object properties are lifted.
-
-##### `allowMissingFields`
+#### `allowMissingFields`
 
 A `Collection` with `allowMissingFields: true` (for example, a checkout `billingAddress` referenced
 only by id) tolerates absent keys. On a value object an absent field denormalizes to `null`, so the
 generator relaxes presence constraints when lifting: each `NotBlank` gains `allowNull: true` and
-each `NotNull` is dropped — an absent field passes, a present-but-empty one still fails. When two
-contributors disagree for the same field and group, the **relaxed** `NotBlank` supersedes the strict
-one, so the lenient (for example, address-by-id) context is not rejected.
+each `NotNull` is dropped — an absent field passes, a present-but-empty one still fails.
 
-#### When to use `objectName`
+### Cross-module field contribution
 
-Use it for any object shape that recurs across resources — `Pagination`, `Totals`, `Address`,
-`Customer`, money `Calculations`, and similar. Omit it for a one-off object that only one resource
-uses, unless you want the cleaner canonical class name. `objectName` applies to **top-level**
-resource properties; an object nested inside another object stays a per-parent class.
+Because each resource owns its value-object class, a nested object's fields can still be
+contributed from several modules — this is how you keep the dependency direction correct, with
+each field declared in its owning module. Multiple modules ship a same-named `*.resource.yml`
+fragment for the same resource, and the schema merger **deep-merges nested object `properties`**
+(and `items.properties` for collections) rather than letting a later fragment's nested block
+replace an earlier one.
+
+For example, both `DiscountsRestApi` and `ProductOptionsRestApi` add fields to the cart-items
+`calculations` object:
+
+```yaml
+# DiscountsRestApi — cart-items.resource.yml
+resource:
+    name: CartItems
+    properties:
+        calculations:
+            type: object
+            properties:
+                discountTotal: { type: integer }
+
+# ProductOptionsRestApi — cart-items.resource.yml
+resource:
+    name: CartItems
+    properties:
+        calculations:
+            type: object
+            properties:
+                productOptionTotal: { type: integer }
+```
+
+The merged `calculations` object carries **both** `discountTotal` and `productOptionTotal`, and a
+single `CartItemsCalculationsStorefrontResource` value object is generated for it. This deep merge —
+not a shared class — is how identically-named objects accumulate fields across modules while each
+resource keeps its own independent request/response shape.
 
 ## Documenting nested properties for OpenAPI and Swagger UI
 

--- a/docs/dg/dev/architecture/api-platform/resource-schemas.md
+++ b/docs/dg/dev/architecture/api-platform/resource-schemas.md
@@ -453,6 +453,67 @@ totals:
 generates a `CartsTotals` class with `public ?CartsTotalsTax $tax = null;`, plus a separate
 `CartsTotalsTax` class with `public ?int $amount = null;`.
 
+### Shared canonical objects
+
+By default a typed nested object generates a **per-resource** class (`CartsTotals`,
+`OrdersTotals`, …). Many resources carry the same conceptual object — pagination metadata, money
+totals, addresses, customer summaries — and generating a separate class for each is wasteful.
+
+Add `objectName` to a `type: object` property to share **one canonical class** across resources:
+
+```yaml
+# carts.resource.yml
+totals:
+    type: object
+    objectName: Totals
+    properties:
+        subtotal:   { type: integer, openapiContext: { example: 16058 } }
+        grandTotal: { type: integer, openapiContext: { example: 14601 } }
+        priceToPay: { type: integer, openapiContext: { example: 14601 } }
+
+# orders.resource.yml
+totals:
+    type: object
+    objectName: Totals
+    properties:
+        subtotal:          { type: integer, openapiContext: { example: 9902 } }
+        grandTotal:        { type: integer, openapiContext: { example: 10392 } }
+        canceledTotal:     { type: integer, openapiContext: { example: 0 } }
+        remunerationTotal: { type: integer, openapiContext: { example: 0 } }
+```
+
+Both properties are typed `?Totals`, and a single `Generated\Api\{ApiType}\Totals` class is
+generated whose fields are the **union** of every contribution (the *canonical superset* — here
+`subtotal`, `grandTotal`, `priceToPay`, `canceledTotal`, `remunerationTotal`, …). A resource
+references the canonical class even if it never populates some of the fields.
+
+`objectName` supports three forms:
+
+| Declaration | Effect |
+|-------------|--------|
+| `type: object` + `objectName: X` + `properties:` | Contributes its fields to canonical object `X`; property typed `?X`. |
+| `type: object` + `objectName: X` (no `properties:`) | Pure reference — typed `?X`, contributes nothing. |
+| `type: object` + `properties:` (no `objectName`) | Per-resource class `{Resource}{Property}` (the default described above). |
+
+#### Conflict policy
+
+Because a canonical object's fields arrive from many files, the generator applies a deterministic
+merge:
+
+- A field declared by multiple contributions **must have the same `type`** — a mismatch is a
+  hard generation error naming the contributing files.
+- For `description`, `openapiContext`, and `nullable`, the **first contribution wins** (resources
+  are processed in a stable, path-sorted order), so the generated schema is reproducible.
+- An `objectName` that is referenced but never receives a `properties` contribution is a hard
+  error, as is a canonical name that collides with a generated resource class.
+
+#### When to use `objectName`
+
+Use it for any object shape that recurs across resources — `Pagination`, `Totals`, `Address`,
+`Customer`, money `Calculations`, and similar. Omit it for a one-off object that only one resource
+uses, unless you want the cleaner canonical class name. `objectName` applies to **top-level**
+resource properties; an object nested inside another object stays a per-parent class.
+
 ## Documenting nested properties for OpenAPI and Swagger UI
 
 Many endpoints accept or return structured JSON payloads — for example, a payment initialization

--- a/docs/dg/dev/architecture/api-platform/resource-schemas.md
+++ b/docs/dg/dev/architecture/api-platform/resource-schemas.md
@@ -450,6 +450,8 @@ totals:
             properties:
                 amount:
                     type: integer
+                    description: 'Tax amount in cents.'
+                    openapiContext: { example: 1457 }
 ```
 
 on the storefront `Carts` resource generates a `CartsTotalsStorefrontResource` class with

--- a/docs/dg/dev/architecture/api-platform/resource-schemas.md
+++ b/docs/dg/dev/architecture/api-platform/resource-schemas.md
@@ -504,8 +504,55 @@ merge:
   hard generation error naming the contributing files.
 - For `description`, `openapiContext`, and `nullable`, the **first contribution wins** (resources
   are processed in a stable, path-sorted order), so the generated schema is reproducible.
+- Validation constraints are the exception to first-wins: they are **unioned** across all
+  contributors (see [Validation on canonical objects](#validation-on-canonical-objects) below).
 - An `objectName` that is referenced but never receives a `properties` contribution is a hard
   error, as is a canonical name that collides with a generated resource class.
+
+#### Validation on canonical objects
+
+A canonical object property denormalizes the incoming JSON into a typed value object, not an array.
+A field validation written the array-shaped way — an `Assert\Collection` on the property in the
+resource's `{resource-name}.validation.yml` — would therefore reject the object value with a 422
+(`This value should be of type array`). The generator resolves this automatically: it **lifts** the
+`Collection.fields` constraints off the property and onto the matching fields of the canonical value
+object, and emits a plain `#[Assert\Valid]` cascade on the property instead of the `Collection`.
+
+You keep authoring validation exactly as before — write the `Collection` against the object property:
+
+```yaml
+# checkout-data.validation.yml
+post:
+    customer:
+        - Optional:
+              constraints:
+                  - Collection:
+                        allowExtraFields: true
+                        fields:
+                            email:
+                                - NotBlank: { message: 'Email is invalid.' }
+                                - Email:    { message: 'Email is invalid.' }
+```
+
+The merge rules across contributors:
+
+- **Per-resource grouping.** Each lifted constraint is re-grouped through the contributing
+  resource's operation groups, so a `customer.email` rule from checkout stays in the
+  `checkout:create` group and does not leak onto other resources sharing the `Customer` object.
+- **Union + dedup.** A field's constraints are unioned across every contributing resource and
+  deduplicated, so the canonical value object carries the superset of all contributors' rules.
+- **Array properties keep `Collection`.** A property with `type: object` *without* `objectName`
+  (or a list property like `payments` / `shipments`) is still validated by its array-shaped
+  `Collection` — only canonical-object properties are lifted.
+
+##### `allowMissingFields`
+
+A `Collection` with `allowMissingFields: true` (e.g. a checkout `billingAddress` referenced only by
+id) tolerates absent keys. On a value object an absent field denormalizes to `null`, so the
+generator relaxes presence constraints when lifting: each `NotBlank` gains `allowNull: true` and
+each `NotNull` is dropped — an absent field passes, a present-but-empty one still fails. When two
+contributors disagree for the same field and group, the **relaxed** `NotBlank` supersedes the strict
+one, so the lenient (e.g. address-by-id) context is not rejected.
 
 #### When to use `objectName`
 

--- a/docs/dg/dev/upgrade-and-migrate/upgrade-to-api-platform-typed-nested-objects.md
+++ b/docs/dg/dev/upgrade-and-migrate/upgrade-to-api-platform-typed-nested-objects.md
@@ -1,0 +1,141 @@
+---
+title: Upgrade API Platform resources to typed nested objects
+description: How to update your project to the typed nested object schema DSL, which modules must move together, and how to recognize a partial update.
+last_updated: Jul 13, 2026
+template: howto-guide-template
+related:
+  - title: Resource Schemas
+    link: docs/dg/dev/architecture/api-platform/resource-schemas.html
+  - title: Validation Schemas
+    link: docs/dg/dev/architecture/api-platform/validation-schemas.html
+---
+
+This document describes how to upgrade a project to the typed nested objects update of the API Platform stack. The update changes how structured JSON objects inside API resources — cart and order `totals`, cart-item `calculations`, checkout `customer` and address objects, `pagination`, and similar — are declared, generated, validated, and serialized.
+
+After the upgrade, a `type: object` property with nested `properties:` generates a dedicated PHP value-object class (for example, `Generated\Api\Storefront\Carts\CartsTotalsStorefrontObject`) instead of an untyped array, and the OpenAPI document publishes a full field-by-field schema for it. The JSON on the wire stays the same for read endpoints; several write endpoints gain stricter, more precise validation. For the concept documentation, see [Resource Schemas](/docs/dg/dev/architecture/api-platform/resource-schemas.html).
+
+{% info_block errorBox "Update all listed modules together" %}
+
+The modules in this release reference each other's new behavior at runtime. To stop a project from updating only part of the set, `spryker/api-platform` and every consumer module now declare composer `conflict` constraints against the previous minors: composer refuses a partial update instead of installing a broken combination (see [Troubleshooting a partial update](#troubleshooting-a-partial-update) for what a bypassed conflict looks like). Update every listed module in one composer run.
+
+{% endinfo_block %}
+
+## Prerequisites
+
+- API Platform is integrated as described in [How to integrate API Platform](/docs/dg/dev/upgrade-and-migrate/integrate-api-platform.html).
+- Your project consumes one or more of the modules listed in the next section on their API Platform (schema-based) endpoints.
+
+## 1. Update the modules — in one composer run
+
+The two platform modules are hard prerequisites for every other module in the list:
+
+| Module | Minimum version | Why it must move |
+|---|---|---|
+| `spryker/api-platform` | `1.23.0` | Parses the new YAML DSL (`type: object` + nested `properties`, `items`, `objectName`, `synthesizeMissingFieldsWhenEmpty`) and generates the companion value-object classes. Older versions silently strip the new keys and generate broken `?object` properties. |
+| `spryker/serializer` | `1.1.0` | Hydrates nested typed objects on the response path (`ReflectionExtractor`-backed denormalization) and reduces `Decimal` value objects to scalars. Older versions throw on every response that carries a typed nested object. |
+
+Consumer modules shipping the new schema DSL (update every one of these that your project has installed):
+
+`spryker/agent-auth-rest-api`, `spryker/availability-notifications-rest-api`, `spryker/carts-rest-api`, `spryker/catalog-search-rest-api`, `spryker/checkout-rest-api`, `spryker/cms-pages-rest-api`, `spryker/configurable-bundle-carts-rest-api`, `spryker/discounts-rest-api`, `spryker/merchants-rest-api`, `spryker/orders-rest-api`, `spryker/payments-rest-api`, `spryker/product-availabilities-rest-api`, `spryker/product-bundle-carts-rest-api`, `spryker/product-configuration-shopping-lists-rest-api`, `spryker/product-configuration-wishlists-rest-api`, `spryker/product-measurement-units-rest-api`, `spryker/product-options-rest-api`, `spryker/product-reviews-rest-api`, `spryker/quote-request-agents-rest-api`, `spryker/quote-requests-rest-api`, `spryker/sales-returns-rest-api`, `spryker/shipments-rest-api`, `spryker/store-context`, `spryker/wishlists-rest-api`, `spryker-feature/self-service-portal`
+
+Run the update as a single command so composer resolves the set together, for example:
+
+```bash
+composer update spryker/api-platform spryker/serializer \
+  spryker/carts-rest-api spryker/checkout-rest-api spryker/orders-rest-api \
+  spryker/discounts-rest-api spryker/product-options-rest-api \
+  # ...every module from the list that is installed in your project
+  --with-dependencies
+```
+
+If composer reports a conflict such as `spryker/carts-rest-api ... conflicts with spryker/api-platform <1.23.0`, you are trying to move a consumer module without moving `spryker/api-platform` (or `spryker/serializer`) to the new minor. Add the platform modules to the same `composer update` command rather than working around the constraint — a project that vendors or aliases past the conflict will hit the runtime symptoms in [Troubleshooting a partial update](#troubleshooting-a-partial-update).
+
+{% info_block warningBox "The cart-items field set moves together" %}
+
+This release moves cart-item field ownership between modules: `spryker/carts-rest-api` no longer declares the cross-domain fields (`salesUnit`, `productOptions`, `configuredBundle`, and others) and no longer passes `calculations` through as a free-shape map. The discount and product-option parts of `calculations` are now contributed by `spryker/discounts-rest-api` and `spryker/product-options-rest-api`.
+
+If you update `spryker/carts-rest-api` without also updating `spryker/discounts-rest-api`, `spryker/product-options-rest-api`, `spryker/configurable-bundle-carts-rest-api`, and `spryker/product-measurement-units-rest-api`, the discount and product-option aggregation fields (`unitDiscountAmountAggregation`, `sumDiscountAmountAggregation`, `unitDiscountAmountFullAggregation`, `sumDiscountAmountFullAggregation`, `unitProductOptionPriceAggregation`, `sumProductOptionPriceAggregation`) disappear from `cart-items` and `guest-cart-items` responses **silently** — no error is raised.
+
+{% endinfo_block %}
+
+## 2. Regenerate API classes and warm the cache
+
+```bash
+vendor/bin/glue api:generate
+GLUE_APPLICATION=GLUE_STOREFRONT vendor/bin/glue cache:clear
+GLUE_APPLICATION=GLUE_STOREFRONT vendor/bin/glue cache:warmup
+```
+
+Repeat the cache commands with `GLUE_APPLICATION=GLUE_BACKEND` if you consume backend API resources (for example, the stores resource). In a Docker-based environment, restart the Glue containers afterwards so OPcache picks up the regenerated classes.
+
+## 3. Adjust project-level schema contributions
+
+If your project ships its own `*.resource.yml` fragments that add fields to any of the affected objects (for example, extra fields on cart `totals` or cart-item `calculations`), convert them to the typed form. The schema merger only deep-merges nested object fields when **both** contributors declare `type: object` with `properties:`. A project fragment that still declares the property as `type: map` or `type: array` now **fails generation with an error** that names the property and both source files, instead of silently replacing the core module's typed declaration.
+
+Before (fails generation — do not keep this):
+
+```yaml
+calculations:
+    type: map
+```
+
+After (merges your fields into the shared typed object):
+
+```yaml
+calculations:
+    type: object
+    properties:
+        myProjectField:
+            type: integer
+            description: 'Project-specific aggregation.'
+```
+
+If you genuinely intend to re-shape a core property wholesale (for example, collapse a typed object back into a map), set `replace: true` on your overriding declaration to opt out of the guard.
+
+## 4. Adjust project code that reads these properties as arrays
+
+Resource properties migrated to typed objects are no longer arrays. Custom providers, processors, relationship resolvers, mappers, and tests that do array access on them must switch to the typed accessors:
+
+```php
+// Before
+$grandTotal = $resource->totals['grandTotal'];
+
+// After
+$grandTotal = $resource->totals?->getGrandTotal();
+// or, where an array is genuinely needed:
+$totals = $resource->totals?->toArray();
+```
+
+The generated value objects also provide `fromArray()` for constructing them from transfer data.
+
+## 5. Review custom validation for writable objects
+
+Validation you authored as an `Assert\Collection` against a writable object property (for example, checkout `billingAddress` rules in a project `checkout-data.validation.yml`) keeps working: the generator automatically lifts the `Collection.fields` constraints onto the generated value-object class and replaces the property constraint with an `#[Assert\Valid]` cascade.
+
+Note the `allowMissingFields: true` semantics on value objects: an absent field denormalizes to `null`, so lifted `NotBlank` constraints gain `allowNull: true` and `NotNull` constraints are dropped — absent passes, present-but-empty still fails. See [Validation Schemas](/docs/dg/dev/architecture/api-platform/validation-schemas.html) for details.
+
+## 6. Regenerate API clients
+
+The OpenAPI document now publishes named component schemas for the nested objects instead of opaque `object` types. If you generate typed API clients (frontend SDKs, contract tests) from the OpenAPI document, regenerate them after the upgrade.
+
+## Behavioral changes to expect after a complete upgrade
+
+These apply even when every module is updated correctly:
+
+- **Empty required objects are rejected with per-field errors.** Submitting `{}` for a required object (for example, a checkout address) now returns a `422` listing each missing field, instead of the previous behavior.
+- **Closed field sets on typed objects.** Objects migrated from `map`/`mixed` to `type: object` serialize only their declared fields. Undeclared keys that previously leaked through the free-shape passthrough no longer appear in responses. If your storefront relied on such a key, contribute it explicitly via a project schema fragment (step 3).
+- **Pagination attributes are stripped of `null` noise.** Non-first collection items and single-item responses no longer carry a `pagination` attribute filled with `null` values.
+- **Shipment address normalization.** Empty-string address fields in checkout-data shipments and order-shipments responses are now returned as `null`.
+
+## Troubleshooting a partial update
+
+Composer refuses a straightforward partial update, but a project that vendored, aliased, or otherwise bypassed the `conflict` constraints can still end up on a mismatched set. All of these ship a green `glue api:generate`; the failures appear only on live requests.
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `500` on `GET /carts`, `/guest-carts`, `/customers-carts` with `Failed to denormalize attribute "totals" ... Expected argument of type "?object", "array" given` | A consumer module was updated but `spryker/api-platform` was not — the old generator typed the property as bare `?object` and dropped the nested schema | Update `spryker/api-platform` and `spryker/serializer`, regenerate, warm cache |
+| `500` with `Error: Class "Generated\Api\Storefront\...\...StorefrontObject" not found` on collection endpoints (returns, orders, merchants, CMS pages, product reviews, search) | Same — the companion value-object classes are only emitted by the new generator | Same as above |
+| `400`/`422` on `POST /checkout`, `/checkout-data`, `/payments` for every request carrying `customer`, `billingAddress`, `shippingAddress`, or `payment` | Same skew on the write path — the request is rejected during denormalization before your processor runs | Same as above |
+| `500` with `Expected argument of type "Generated\Api\Storefront\...StorefrontObject or null", "array" given at property path "totals"` | `spryker/api-platform` is new but `spryker/serializer` is old — response hydration cannot recurse into typed nested objects | Update `spryker/serializer` |
+| Discount / product-option aggregation fields missing from `cart-items.calculations` (no error) | `spryker/carts-rest-api` updated without `spryker/discounts-rest-api` / `spryker/product-options-rest-api` | Update the domain modules |
+| Core fields missing from a typed object your project extends | A project `*.resource.yml` fragment still declares the property as `type: map`/`array` and replaces the typed core declaration | Convert the fragment to `type: object` with `properties:` (step 3) |


### PR DESCRIPTION
## Summary

Documents the API Platform typed-nested-object DSL in `resource-schemas.md`, matching the shipped per-resource design (spryker/suite#740). Consolidates the former two-PR stack (absorbs the typed-nested-objects section that was #3760).

- **Typed nested objects** — a `type: object` property with nested `properties:` generates a `final` companion value-object class (no `#[ApiResource]`) in `Generated\Api\{ApiType}\`, named `{ResourceName}{PropertyPath}{ApiType}Resource`, plus a named OpenAPI schema; covers what/why/when (`object` vs `map` vs `mixed`) and object-within-object nesting.
- **Object collections** — a `type: array` of typed-object `items:` generates an element value object named after the pluralized field segment.
- **Per-resource validation lifting** — a `Collection` on a writable object property is lifted onto that resource's value-object fields (with `#[Assert\Valid]` on the property); each resource has its own value object, so there is no cross-resource union. `allowMissingFields` relaxes `NotBlank`/`NotNull`.
- **Cross-module field contribution** — same-named `*.resource.yml` fragments deep-merge nested `properties` so modules accumulate fields on a shared object without a shared class.

## Related

- Implementation PR: spryker/suite#740
- CC-39249: https://spryker.atlassian.net/browse/CC-39249

## Test plan

Docs-only — touches `docs/dg/dev/architecture/api-platform/resource-schemas.md`. Verified naming, collection pluralization, validation lifting, and SchemaMerger nested deep-merge against the generator code in suite#740.
