### PR TITLE
Restore orphaned payment-methods pages to dg_dev sidebar (Stage A)

### DIFF
--- a/_data/sidebars/dg_dev_sidebar.yml
+++ b/_data/sidebars/dg_dev_sidebar.yml
@@ -441,6 +441,53 @@ entries:
         - title: Add events
           url: /docs/dg/dev/backend-development/data-manipulation/event/add-events.html
 
+      - title: Payment methods
+        url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/payment-methods.html
+        nested:
+        - title: Invoice
+          nested:
+          - title: Implement invoice payment
+            url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/invoice/implement-invoice-payment.html
+          - title: Implement invoice payment in shared layer
+            url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/invoice/implement-invoice-payment-in-shared-layer.html
+          - title: Implement invoice payment in backend
+            url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/invoice/implement-invoice-payment-in-backend.html
+          - title: Implement invoice payment in frontend
+            url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/invoice/implement-invoice-payment-in-frontend.html
+          - title: Integrate invoice payment into checkout
+            url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/invoice/integrate-invoice-payment-into-checkout.html
+          - title: Test the invoice payment implementation
+            url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/invoice/test-the-invoice-payment-implementation.html
+        - title: Prepayment
+          nested:
+          - title: Implement prepayment
+            url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/prepayment/implement-prepayment.html
+          - title: Implement prepayment in shared layer
+            url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/prepayment/implement-prepayment-in-shared-layer.html
+          - title: Implement prepayment in backend
+            url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/prepayment/implement-prepayment-in-backend.html
+          - title: Implement prepayment in frontend
+            url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/prepayment/implement-prepayment-in-frontend.html
+          - title: Integrate prepayment into checkout
+            url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/prepayment/integrate-prepayment-into-checkout.html
+          - title: Test the prepayment implementation
+            url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/prepayment/test-the-prepayment-implementation.html
+        - title: Direct Debit example implementation
+          url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/direct-debit-example-implementation/direct-debit-payment.html
+          nested:
+          - title: Implement Direct Debit payment
+            url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/direct-debit-example-implementation/implement-direct-debit-payment.html
+          - title: Implement Direct Debit in the shared layer
+            url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/direct-debit-example-implementation/implement-direct-debit-in-the-shared-layer.html
+          - title: Implement Direct Debit in Zed
+            url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/direct-debit-example-implementation/implement-direct-debit-in-zed.html
+          - title: Implement Direct Debit in Yves
+            url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/direct-debit-example-implementation/implement-direct-debit-in-yves.html
+          - title: Integrate Direct Debit into checkout
+            url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/direct-debit-example-implementation/integrate-direct-debit-into-checkout.html
+          - title: Test your Direct Debit implementation
+            url: /docs/dg/dev/backend-development/data-manipulation/payment-methods/direct-debit-example-implementation/test-your-direct-debit-implementation.html
+
     - title: Extend Spryker
       url: /docs/dg/dev/backend-development/extend-spryker/extend-spryker.html
       nested:


### PR DESCRIPTION
## Summary

Executes **Stage A** of the `docs/dg/dev` restructuring plan: restores 20 published payment-methods pages that were orphaned from the sidebar and therefore unreachable via site navigation.

Adds a **Payment methods** node under **Backend development → Data manipulation** with three sub-groups:
- **Invoice** (6 pages)
- **Prepayment** (6 pages)
- **Direct Debit example implementation** (1 landing + 6 pages)

## Why

`_scripts/sidebar_checker/sidebar_checker.sh` reported 20 missing DG Dev pages. The content is real and linked from `data-manipulation.md` and the PBC payments feature overview, but had no navigation path.

## Scope & safety

- **Sidebar-only:** one file changed (`_data/sidebars/dg_dev_sidebar.yml`, +47 lines).
- No content files moved or edited, no URL changes, no redirects, no `last_updated` bumps.
- Titles taken verbatim from each page's frontmatter; entries nested to match sibling indentation.

## Verification

- Before: sidebar checker reported 20 missing DG Dev pages.
- After: `bash _scripts/sidebar_checker/sidebar_checker.sh` exits 0 — zero missing, zero extra.

> Stacked on `feature/claude-docs-agents` (base branch) so this diff shows only the sidebar change. Stages B–E (typo-slug renames, dev-tools de-dup, lifecycle grouping, structural moves) were intentionally not started — several require human decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)