### PR TITLE
ci: auto-bump stale last_updated dates on PRs

### DIFF
--- a/.github/workflows/check_last_modified.yml
+++ b/.github/workflows/check_last_modified.yml
@@ -5,6 +5,13 @@ on:
     types:
       - opened
       - synchronize
+      - labeled
+    # Archived docs are intentionally frozen with old dates, so never run this
+    # check (or its auto-bump push) against any archive branch (archive,
+    # archive-doc-*, manual_archive_*, product-release-archive-*, …).
+    branches-ignore:
+      - '*archive*'
+      - '**/*archive*'
 
 permissions:
   contents: write
@@ -37,8 +44,18 @@ jobs:
           echo "last_updated is stale, but this is a fork PR and can't be auto-fixed. Please bump last_updated to the current date."
           exit 1
 
+      # Auto-bumping pushes a bot commit to the PR branch, so it is opt-in: it only runs
+      # when the maintainer adds the "Allow autofix" label. Without it, stale dates are a
+      # hard failure (next step) and the author bumps them by hand. Adding the label fires
+      # a `labeled` event, so the fix runs without needing a fresh push.
+      - name: Fail when stale and autofix not allowed
+        if: steps.detect.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository && !contains(github.event.pull_request.labels.*.name, 'Allow autofix')
+        run: |
+          echo "last_updated is stale. Bump it to the current date, or add the 'Allow autofix' label to let the bot bump it for you."
+          exit 1
+
       - name: Bump stale last_updated dates to today
-        if: steps.detect.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.detect.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'Allow autofix')
         env:
           STALE_LIST_FILE: ${{ runner.temp }}/stale_last_updated.txt
         run: |
@@ -54,7 +71,7 @@ jobs:
           done < <(sort -u "$STALE_LIST_FILE")
 
       - name: Commit and push date bumps
-        if: steps.detect.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.detect.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'Allow autofix')
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "docs: auto-bump stale last_updated to current date"
@@ -67,7 +84,7 @@ jobs:
       # pull_request run that re-validates and converges — the second run finds the dates
       # current, records nothing, and pushes nothing, so there is no commit loop.
       - name: Re-verify after auto-fix
-        if: steps.detect.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository
+        if: steps.detect.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'Allow autofix')
         env:
           GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |

--- a/.github/workflows/check_last_modified.yml
+++ b/.github/workflows/check_last_modified.yml
@@ -6,6 +6,9 @@ on:
       - opened
       - synchronize
 
+permissions:
+  contents: write
+
 jobs:
   check-sidebar-links:
     runs-on: ubuntu-latest
@@ -15,8 +18,58 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          ref: ${{ github.head_ref }}
 
       - name: Check last_updated is not older than 30 days for files with 1 changed line
+        id: detect
+        continue-on-error: true
         env:
           GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          STALE_LIST_FILE: ${{ runner.temp }}/stale_last_updated.txt
         run: /bin/bash ./_scripts/last_updated_checker.sh 1 30
+
+      # Fork PRs run with a read-only token, so the bot can't push a fix. Surface the
+      # drift as a hard failure instead of silently passing the continue-on-error step.
+      - name: Fail on fork PRs that can't be auto-fixed
+        if: steps.detect.outcome == 'failure' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "last_updated is stale, but this is a fork PR and can't be auto-fixed. Please bump last_updated to the current date."
+          exit 1
+
+      - name: Bump stale last_updated dates to today
+        if: steps.detect.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          STALE_LIST_FILE: ${{ runner.temp }}/stale_last_updated.txt
+        run: |
+          if [ ! -s "$STALE_LIST_FILE" ]; then
+            echo "Checker failed but no auto-fixable file was recorded (e.g. a missing last_updated field). Failing."
+            exit 1
+          fi
+          TODAY=$(LC_ALL=C date '+%b %-d, %Y')
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            echo "Bumping last_updated -> $TODAY in $file"
+            sed -i -E "s/^last_updated:.*/last_updated: ${TODAY}/" "$file"
+          done < <(sort -u "$STALE_LIST_FILE")
+
+      - name: Commit and push date bumps
+        if: steps.detect.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "docs: auto-bump stale last_updated to current date"
+          commit_user_name: spryker-docs-bot
+          commit_user_email: spryker-docs-bot@users.noreply.github.com
+          file_pattern: '**/*.md'
+
+      # Confirm the bump resolved the drift in this run. Uses the post-commit local HEAD
+      # (the event's head SHA predates the fix commit). The push above also fires a fresh
+      # pull_request run that re-validates and converges — the second run finds the dates
+      # current, records nothing, and pushes nothing, so there is no commit loop.
+      - name: Re-verify after auto-fix
+        if: steps.detect.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          export GITHUB_HEAD_SHA="$(git rev-parse HEAD)"
+          /bin/bash ./_scripts/last_updated_checker.sh 1 30

--- a/_scripts/last_updated_checker.sh
+++ b/_scripts/last_updated_checker.sh
@@ -3,10 +3,24 @@
 set -e
 
 BASE_SHA="${GITHUB_BASE_SHA:-HEAD^}"
-HEAD_SHA="${GITHUB_SHA:-HEAD}"
+# Prefer the real PR head over GITHUB_SHA: on pull_request events GITHUB_SHA is the
+# merge commit (PR merged into the current base), so a "$BASE_SHA"..."$HEAD_SHA" diff
+# sweeps in unrelated base-branch changes and blames this PR for them. The PR head SHA
+# scopes the diff to what this PR actually changed.
+HEAD_SHA="${GITHUB_HEAD_SHA:-${GITHUB_SHA:-HEAD}}"
 lines_changed_limit="${1:-1}"
 lines_changed_day_limit="${2:-30}"
 files_needing_update=0
+
+# When set, append each file with an auto-fixable stale last_updated date here so a
+# follow-up CI step can bump it. Missing-field cases are intentionally not recorded:
+# they can't be fixed by bumping a date and must stay a hard failure.
+STALE_LIST_FILE="${STALE_LIST_FILE:-}"
+record_stale() {
+  if [ -n "$STALE_LIST_FILE" ]; then
+    echo "$1" >> "$STALE_LIST_FILE"
+  fi
+}
 
 echo "Lookging for files with at least $lines_changed_limit line(s) changed and last_updated older than $lines_changed_day_limit days "
 echo ""
@@ -40,6 +54,7 @@ for file in $changed_md_files; do
     fi
     echo "Modified file $file contains too old modified last_updated: $date_string."
     files_needing_update=1
+    record_stale "$file"
     continue
   else
     if echo "$front_matter" | grep -q "^last_updated:"; then
@@ -61,6 +76,7 @@ for file in $changed_md_files; do
   if [ "$lines_changed" -gt "$lines_changed_limit" ]; then
     echo "Modified file $file has $lines_changed changed lines, old and not updated last_updated: $date_string."
     files_needing_update=1
+    record_stale "$file"
   fi
 done
 


### PR DESCRIPTION
## Summary

Makes the `last_updated` 30-day check **self-healing** and fixes the false positives it currently produces.

**Changes to `check_last_modified.yml` + `_scripts/last_updated_checker.sh`:**

1. **Fix false positives.** The checker diffed `base.sha...GITHUB_SHA`, but on `pull_request` events `GITHUB_SHA` is the *merge commit* (PR merged into current master). That diff sweeps in unrelated base-branch changes, so files the PR never touched (carrying their own old dates) get blamed on the PR. Now it diffs against the real PR head (`github.event.pull_request.head.sha`), scoping detection to what the PR actually changed.

2. **Auto-fix genuine drift (opt-in via label).** When a file the PR *did* change has a stale `last_updated`, the workflow bumps it to today (`Jun 22, 2026` format) and pushes the fix back to the PR branch via `git-auto-commit-action`, then re-verifies in-run. The push fires one fresh run that converges (dates now current → nothing to commit → no loop).

   Auto-bump pushes a bot commit, so it is **opt-in**: it only runs when the maintainer adds the **`Allow autofix`** label. Without the label, stale dates are a hard failure and the author bumps them by hand. Adding the label fires a `labeled` event, so the fix runs without needing a fresh push.

3. **Never run on archive branches.** Archived docs are intentionally frozen with old dates, so the check (and its auto-bump push) is skipped entirely when the PR targets an archive branch — `branches-ignore: '*archive*'` / `'**/*archive*'`.

**Safeguards:**
- PRs against archive branches → workflow does not trigger at all.
- Stale dates without the `Allow autofix` label → hard fail with a "bump manually or add the label" message.
- Fork PRs (read-only token, can't push) → hard fail with a bump-it-yourself message.
- Missing `last_updated` field (can't be fixed by bumping) → hard fail.
- Adds `permissions: contents: write` and checks out `github.head_ref` so the bot can push.

## Why

Surfaced by spryker/spryker-docs#3761, where an in-date PR was failed for master's own stale `troubleshooting.md` / `enable-dynamic-multistore.md` dates pulled in via the merge-commit diff.

The label gate and archive guard come from review feedback: auto-bump should never push to frozen archive branches, and maintainers want to opt in before the bot commits to a PR.

## Test plan

Verified locally:
- Original #3761 inputs with the head-SHA fix → no false positives (exit 0).
- Synthetic PR that edits a body but not the date → flagged, recorded, bumped to `Jun 22, 2026`, re-verify passes (exit 0).
- `bash -n` clean; only a pre-existing shellcheck style nit on an untouched line.
