### PR TITLE
Add Commerce MCP Server documentation

### DIFF
--- a/_data/sidebars/dg_dev_sidebar.yml
+++ b/_data/sidebars/dg_dev_sidebar.yml
@@ -93,6 +93,8 @@ entries:
             nested:
               - title: Install Smart CMS Content Assistant
                 url: /docs/dg/dev/ai/ai-commerce/content-assistant/install-smart-cms-content-assistant.html
+          - title: Commerce MCP Server
+            url: /docs/dg/dev/ai/ai-commerce/commerce-mcp-server/commerce-mcp-server.html
       - title: AI Dev SDK
         url: /docs/dg/dev/ai/ai-dev/ai-dev.html
         nested:

--- a/_data/sidebars/pbc_all_sidebar.yml
+++ b/_data/sidebars/pbc_all_sidebar.yml
@@ -19,6 +19,8 @@ entries:
             url: /docs/pbc/all/ai-commerce/latest/smart-pim.html
           - title: Smart CMS Content Assistant
             url: /docs/pbc/all/ai-commerce/latest/smart-cms-content-assistant.html
+          - title: Commerce MCP Server
+            url: /docs/pbc/all/ai-commerce/latest/commerce-mcp-server.html
 
       - title: Yves
         nested:

--- a/docs/dg/dev/ai/ai-commerce/commerce-mcp-server/commerce-mcp-server.md
+++ b/docs/dg/dev/ai/ai-commerce/commerce-mcp-server/commerce-mcp-server.md
@@ -1,0 +1,124 @@
+---
+title: Commerce MCP Server
+description: Technical overview of the Commerce MCP Server — architecture, transports, available tools and prompts, and configuration for connecting AI assistants to the Spryker storefront.
+last_updated: Jun 22, 2026
+template: concept-topic-template
+label: early-access
+keywords: ai, mcp, model context protocol, agentic commerce, storefront, glue api, tools, prompts
+---
+
+The Commerce MCP Server is a standalone [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro) server that exposes Spryker storefront operations as MCP tools and prompts. It enables AI assistants to search the catalog, manage carts, and complete checkout by calling the Spryker Storefront API on the shopper's behalf.
+
+For the business overview, use cases, and capability scope, see [Commerce MCP Server](/docs/pbc/all/ai-commerce/latest/commerce-mcp-server.html).
+
+{% info_block warningBox "Preview capability" %}
+
+This is an early-access preview intended for demonstration, evaluation, and prototyping. It uses simplified security and error handling and is not hardened for production. For production implementations, engage Spryker professional services.
+
+{% endinfo_block %}
+
+{% info_block infoBox "Related MCP server" %}
+
+The Commerce MCP Server connects AI assistants to the *storefront* (the Storefront API). It is distinct from the [AI Dev MCP Server](/docs/dg/dev/ai/ai-dev/ai-dev-mcp-server.html), which exposes *developer* tooling such as transfer structures and OMS transitions to AI assistants working on a Spryker project.
+
+{% endinfo_block %}
+
+## Architecture
+
+The server sits between an MCP client and the Spryker Storefront API. A request flows through the following layers:
+
+```text
+AI assistant (MCP client) -> transport (stdio | HTTP | SSE) -> tool and prompt registries -> Spryker API service -> Spryker Storefront API
+```
+
+- **Transports.** The server supports three transports, selectable at startup: `stdio` for desktop and CLI MCP clients, `HTTP` for request and response integrations, and `SSE` (Server-Sent Events) for real-time web applications.
+- **Tools and prompts.** Each commerce operation is implemented as a tool with a validated input schema. Prompts provide context-aware guidance that helps the assistant choose and combine tools.
+- **Spryker API service.** A central HTTP client handles communication with the Storefront API, including request timeouts, retries with exponential backoff, and structured error responses. Client errors (4xx) are not retried.
+- **Authentication.** Tools accept a token. An authenticated customer token is sent as a bearer token, while a guest session token is sent as an anonymous customer identifier. This lets the same cart and checkout tools serve both authenticated and guest shoppers.
+
+## Available tools
+
+The server provides the following tools for storefront operations.
+
+### Product discovery
+
+| TOOL | DESCRIPTION |
+|------|-------------|
+| `product-search` | Searches the product catalog. Supports a query string, value facets (for example, brand), range facets (for example, price), sorting, and pagination. |
+| `get-product` | Retrieves detailed information for a product by its abstract SKU. |
+
+### Customer access
+
+| TOOL | DESCRIPTION |
+|------|-------------|
+| `authenticate` | Authenticates a customer with a username and password to obtain an access token. If no credentials are provided, it creates an anonymous guest session token. |
+
+### Shopping cart
+
+| TOOL | DESCRIPTION |
+|------|-------------|
+| `add-to-cart` | Adds a product to an authenticated customer's cart by concrete SKU. Creates a cart if none exists. |
+| `guest-add-to-cart` | Adds a product to a guest shopper's cart by concrete SKU. |
+| `get-cart` | Retrieves cart contents and totals for an authenticated or guest shopper. |
+| `update-cart-item` | Updates the quantity of an item in a cart. |
+| `remove-from-cart` | Removes an item from a cart. |
+
+### Checkout and orders
+
+| TOOL | DESCRIPTION |
+|------|-------------|
+| `get-checkout-data` | Retrieves available payment methods, shipment methods, and addresses for a cart. |
+| `checkout` | Places an order from a cart using customer data, billing and shipping addresses, a payment method, and a shipment method. |
+| `get-order` | Retrieves order details and history for an authenticated customer. Returns a specific order when an order reference is provided, or all orders otherwise. |
+
+## Available prompts
+
+The server includes prompts that guide AI assistants through common scenarios. Each prompt explains which tools to use and how to combine them.
+
+| PROMPT | DESCRIPTION |
+|--------|-------------|
+| `product-search` | Guides product discovery and search, including category, price range, and brand filtering. |
+| `cart-management` | Assists with adding, removing, viewing, and updating cart items, and with checkout guidance. |
+| `customer-service` | Supports authentication, order status, and account inquiries. |
+| `order-fulfillment` | Guides the full flow from cart to completed order. |
+| `product-recommendations` | Generates recommendations based on stated preferences and context. |
+
+## Configuration
+
+The server is configured through environment variables, which are validated at startup. The key settings are:
+
+| VARIABLE | DESCRIPTION |
+|----------|-------------|
+| `SPRYKER_API_BASE_URL` | Base URL of the Spryker Storefront API the server connects to. |
+| `SPRYKER_API_TIMEOUT` | Request timeout in milliseconds. |
+| `SPRYKER_API_RETRY_ATTEMPTS` | Number of retry attempts for failed requests. |
+| `SPRYKER_API_RETRY_DELAY` | Base delay between retries in milliseconds, used for exponential backoff. |
+| `MCP_TRANSPORT` | Transport type: `stdio`, `http`, or `sse`. |
+| `MCP_HTTP_PORT`, `MCP_HTTP_HOST`, `MCP_HTTP_ENDPOINT` | Network settings for the HTTP and SSE transports. |
+| `LOG_LEVEL` | Logging verbosity. The level can also be changed at runtime through the MCP `logging/setLevel` request. |
+
+## Connect an AI client
+
+Most desktop and CLI AI assistants connect over the `stdio` transport. You register the server as an MCP server in the client's configuration, providing the command to start it and the `SPRYKER_API_BASE_URL` of your Storefront API.
+
+For example, in a Claude Desktop `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "spryker-commerce": {
+      "command": "npx",
+      "args": ["spryker-mcp-server"],
+      "env": {
+        "SPRYKER_API_BASE_URL": "https://your-storefront-api.com"
+      }
+    }
+  }
+}
+```
+
+After saving the configuration, restart the AI client. The assistant then discovers the available tools and prompts automatically and can start handling commerce requests. Web applications can instead connect over the `HTTP` or `SSE` transport by pointing the client at the configured host, port, and endpoint.
+
+## Compatibility
+
+The server is compatible with the Spryker Commerce OS Storefront API. It uses bearer-token authentication for registered customers and an anonymous customer identifier for guest sessions, and it expects responses in the JSON:API format.

--- a/docs/pbc/all/ai-commerce/latest/commerce-mcp-server.md
+++ b/docs/pbc/all/ai-commerce/latest/commerce-mcp-server.md
@@ -7,7 +7,7 @@ label: early-access
 keywords: ai, mcp, model context protocol, agentic commerce, conversational commerce, storefront, checkout
 ---
 
-The Commerce MCP Server connects AI assistants to your Spryker storefront through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro), an open standard for connecting AI applications to external systems. It turns core commerce operations — product discovery, cart management, and checkout — into a set of standardized tools that any MCP-compatible AI agent, such as Claude or Copilot, can call directly.
+The Commerce MCP Server connects AI assistants to your Spryker storefront through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro), an open standard for connecting AI applications to external systems. It turns core commerce operations — product discovery, cart management, and checkout — into a set of standardized tools that any MCP-compatible AI agent, such as Claude, ChatGPT, or Perplexity, can call directly.
 
 The result is *agentic commerce*: a shopper describes what they want in natural language, and the AI assistant searches the catalog, builds a cart, and completes the order using your existing Spryker Storefront API — without a person navigating the storefront manually.
 

--- a/docs/pbc/all/ai-commerce/latest/commerce-mcp-server.md
+++ b/docs/pbc/all/ai-commerce/latest/commerce-mcp-server.md
@@ -1,0 +1,66 @@
+---
+title: Commerce MCP Server
+description: Expose your Spryker storefront to AI assistants through the Model Context Protocol, so AI agents can search products, manage carts, and complete checkout on behalf of customers.
+last_updated: Jun 22, 2026
+template: concept-topic-template
+label: early-access
+keywords: ai, mcp, model context protocol, agentic commerce, conversational commerce, storefront, checkout
+---
+
+The Commerce MCP Server connects AI assistants to your Spryker storefront through the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/docs/getting-started/intro), an open standard for connecting AI applications to external systems. It turns core commerce operations — product discovery, cart management, and checkout — into a set of standardized tools that any MCP-compatible AI agent, such as Claude or Copilot, can call directly.
+
+The result is *agentic commerce*: a shopper describes what they want in natural language, and the AI assistant searches the catalog, builds a cart, and completes the order using your existing Spryker Storefront API — without a person navigating the storefront manually.
+
+{% info_block warningBox "Preview capability" %}
+
+The Commerce MCP Server is an early-access preview that demonstrates how Spryker commerce can be exposed to AI agents. It is intended for demonstration, evaluation, and prototyping. For a production rollout, engage Spryker professional services.
+
+{% endinfo_block %}
+
+## Problems it solves
+
+Shoppers and buyers increasingly start tasks inside AI assistants rather than on a website. Traditional storefronts are built for human clicks and are not reachable by an AI agent, which creates several challenges:
+
+| CHALLENGE | HOW THE COMMERCE MCP SERVER HELPS |
+|-----------|-----------------------------------|
+| AI assistants cannot transact against a standard storefront. | Exposes commerce operations as MCP tools that any MCP-compatible assistant can discover and call. |
+| Connecting each new AI assistant requires custom, one-off API integration. | Uses a single open protocol (MCP), so one integration works across every MCP-compatible client instead of a separate adapter per assistant. |
+| Catalog search, cart, and checkout each expose different APIs that an agent must learn. | Provides a consistent, documented set of tools with input validation, so the assistant calls clear actions instead of orchestrating raw API calls. |
+| Building an agentic shopping experience usually means replatforming. | Runs on top of your existing Spryker Storefront API — no changes to the underlying commerce platform. |
+
+## What the Commerce MCP Server covers
+
+The server exposes the core path from discovery to order. The following commerce capabilities are available to connected AI assistants:
+
+| AREA | CAPABILITIES |
+|------|--------------|
+| Product discovery | Natural-language catalog search with filtering by facets (for example, brand or price range), sorting, and pagination. Retrieval of detailed product information by SKU. |
+| Shopping cart | Add items to a cart, view cart contents and totals, update item quantities, and remove items. Supported for both guest and authenticated shoppers. |
+| Checkout | Retrieve available payment methods, shipment methods, and addresses, then place an order with customer, billing, shipping, payment, and shipment details. Supported for both guest and authenticated shoppers. |
+| Orders | Retrieve order details and order history for authenticated customers. |
+| Customer access | Authenticate a customer to obtain an access token, or start an anonymous guest session for shopping without an account. |
+
+In addition to these actions, the server ships with built-in guidance for common scenarios — product search, cart management, customer service, order fulfillment, and product recommendations — that help the AI assistant choose and combine the right operations for a shopper's request.
+
+## Current scope
+
+As a preview, the server focuses on the most common storefront journey. Be aware of the following boundaries when evaluating it:
+
+- **Simple products.** The flow targets standard catalog products added by their SKU. Configurable products, bundles, gift cards, and complex product-option selection are not specifically handled.
+- **Demonstration payment.** Checkout defaults to a demonstration payment method (invoice). Integration with a live payment service provider is outside the preview scope.
+- **Order history for authenticated customers.** Retrieving past orders requires an authenticated customer session.
+- **Core journey only.** Capabilities such as promotions and vouchers, wishlists, returns, and marketplace or merchant operations are not part of the current preview.
+
+## Who benefits
+
+| ROLE | BENEFIT |
+|------|---------|
+| Shoppers and B2B buyers | Search, build a cart, and complete an order through a conversational AI assistant, without navigating the storefront manually. |
+| Merchants and business teams | Reach customers on emerging AI-driven channels and offer guided, conversational buying experiences on top of the existing catalog and checkout. |
+| Developers and integrators | Connect AI assistants through one open protocol instead of building a custom integration per assistant, reusing the existing Spryker Storefront API. |
+
+## Developer resources
+
+| RESOURCE | DESCRIPTION |
+|----------|-------------|
+| [Commerce MCP Server](/docs/dg/dev/ai/ai-commerce/commerce-mcp-server/commerce-mcp-server.html) | Technical overview: architecture, transports, available tools and prompts, and configuration. |


### PR DESCRIPTION
## What

Adds documentation for the **Commerce MCP Server** — a standalone Model Context Protocol server that exposes the Spryker storefront (Storefront API) to AI assistants so they can search products, manage carts, and complete checkout on a shopper's behalf.

Follows the established AI Commerce pattern of pairing a business-oriented PBC page with a technical DG page:

- **Business doc** — `docs/pbc/all/ai-commerce/latest/commerce-mcp-server.md`
  Focuses on the problems it solves, what it covers (product discovery, cart, checkout, orders, customer access), current scope/limitations, and who benefits. No install steps.
- **Technical doc** — `docs/dg/dev/ai/ai-commerce/commerce-mcp-server/commerce-mcp-server.md`
  Architecture, transports (stdio/HTTP/SSE), available tools and prompts, configuration variables, how to connect an AI client, and Storefront API compatibility. Distilled from the server README.
- Registers both pages in `pbc_all_sidebar.yml` and `dg_dev_sidebar.yml`, with cross-links between the two pages.

## Notes

- Both pages pass `markdownlint-cli2` with 0 errors and follow the documentation standards (internal link format, American spelling, no contractions, `info_block` usage).
- The server is documented as an **early-access preview**, consistent with its README disclaimer, and is clearly distinguished from the developer-focused [AI Dev MCP Server](https://docs.spryker.com/docs/dg/dev/ai/ai-dev/ai-dev-mcp-server.html).
- Placed under the AI Commerce umbrella as the closest buyer-facing home, while noting in the text that it is a standalone server (not part of the AiFoundation-based AI Commerce package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)