### PR TITLE
CC-39381 Document API Platform router cache warm-up for deployment

### DIFF
--- a/docs/dg/dev/architecture/api-platform.md
+++ b/docs/dg/dev/architecture/api-platform.md
@@ -1,7 +1,7 @@
 ---
 title: API Platform
 description: Spryker's API Platform integration provides schema-based API resource generation with automatic OpenAPI documentation and the integration of the API Platform Bundle.
-last_updated: Jun 10, 2026
+last_updated: Jun 29, 2026
 template: concept-topic-template
 related:
   - title: How to integrate API Platform
@@ -456,17 +456,42 @@ For detailed information, see [Sparse Fieldsets](/docs/dg/dev/architecture/api-p
 
 ### Cache warming
 
-Pre-generate resources during deployment:
+API Platform deployment requires two sequential steps, not alternatives:
+
+1. Generate the API resource classes from the schema files:
 
 ```bash
-docker/sdk cli glue  api:generate
+docker/sdk cli glue api:generate
 ```
 
-or
+2. Warm the application cache—including the **router cache**—once the resources from step 1 exist. Run it per Glue application:
 
 ```bash
-docker/sdk cli glue  cache:warmup
+docker/sdk cli GLUE_APPLICATION=GLUE_STOREFRONT glue cache:warmup
+docker/sdk cli GLUE_APPLICATION=GLUE_BACKEND glue cache:warmup
 ```
+
+API Platform registers its operations as routes in the standard Symfony router, whose compiled matcher and generator are dumped to `data/cache/Glue<Storefront|Backend>/<environment>/url_matching_routes.php` and `url_generating_routes.php`. `cache:warmup` builds these dumps from the resource collection produced in step 1. Add both steps to your deployment and installation recipes for every API Platform application.
+
+{% info_block warningBox "Use cache:warmup, not api:router:cache:warm-up" %}
+
+`api:router:cache:warm-up` warms only the legacy Glue (`GlueApplication`) custom-route router—it does **not** build the API Platform router dump. Use `cache:warmup` (or `cache:clear`) to warm the API Platform router.
+
+{% endinfo_block %}
+
+#### Multi-container and cloud deployments
+
+In production, applications run with debug disabled. The router dump is then written once and never revalidated—whatever route set it was first built from is frozen for the life of the container.
+
+In a single-container setup this is harmless: the cache is warmed in the same place that serves requests, with the full route set. In a multi-container topology where resource generation runs in a build container and requests are served by a separate runtime container (for example, AWS ECS), you must guarantee the router dump is built against the complete resource collection **for the runtime container**—either warmed in the runtime container after deployment, or baked at build time only if `data/cache` is shipped to every runtime replica with the full route set.
+
+If the dump is built before resources are generated (an empty or incomplete collection), the runtime container freezes that empty dump and:
+
+- every API request returns HTTP 404 (Glue code `007`, legacy fallthrough) because the route is absent from the matcher;
+- once the matcher is partially rebuilt, data endpoints return HTTP 500 from IRI generation (`RouteNotFoundException`), because the URL generator dump is also empty;
+- `/docs.json` returns 0 paths, even though `api:debug --list` shows the resources resolving correctly.
+
+To recover a frozen container, clear and re-warm the cache (`cache:clear`) with the full resource collection present.
 
 ### Property-level access control
 

--- a/docs/dg/dev/upgrade-and-migrate/integrate-api-platform.md
+++ b/docs/dg/dev/upgrade-and-migrate/integrate-api-platform.md
@@ -1,7 +1,7 @@
 ---
 title: How to integrate API Platform
 description: This document describes how to integrate API Platform into your Spryker application.
-last_updated: May 29, 2026
+last_updated: Jun 29, 2026
 template: howto-guide-template
 ---
 
@@ -161,6 +161,25 @@ console cache:clear
 # Build Symfony container cache
 console container:build
 ```
+
+## 8. Warm the API Platform router cache
+
+API Platform registers its operations as routes in the standard Symfony router. With debug disabled (production), the compiled router dump is written once and then frozen for the life of the container, so it **must** be built against the fully generated resource collection. After generating resources (step 5), warm the cache for each Glue application:
+
+```bash
+docker/sdk cli GLUE_APPLICATION=GLUE_STOREFRONT glue cache:warmup
+docker/sdk cli GLUE_APPLICATION=GLUE_BACKEND glue cache:warmup
+```
+
+{% info_block warningBox "Required on AWS and any multi-container deployment" %}
+
+This step is mandatory in cloud (AWS ECS) and any split build/runtime topology. If the router dump is built before resources are generated—or never warmed in the runtime container—every API request returns HTTP 404 and the empty dump stays frozen for the life of the container.
+
+Use `cache:warmup` (or `cache:clear`), **not** `api:router:cache:warm-up`, which warms only the legacy Glue router and does not build the API Platform router dump.
+
+For the full explanation, multi-container guidance, and recovery steps, see [Cache warming](/docs/dg/dev/architecture/api-platform.html#cache-warming) and [Multi-container and cloud deployments](/docs/dg/dev/architecture/api-platform.html#multi-container-and-cloud-deployments) in the architecture guide.
+
+{% endinfo_block %}
 
 ## Verification
 


### PR DESCRIPTION
## Summary
Two pages:

- **Architecture — `api-platform.md`:** the *Cache warming* section presented `api:generate` and `cache:warmup` as alternatives—they are sequential steps. Clarifies the order, documents the per-application router cache warm-up (`GLUE_STOREFRONT`/`GLUE_BACKEND`), warns that `api:router:cache:warm-up` warms only the legacy router (not API Platform), and adds a multi-container / cloud (AWS ECS) deployment + troubleshooting section for the frozen-empty-router-dump failure (404 code `007`, 500 on IRI generation, `/docs.json` 0 paths).
- **Integration guide — `integrate-api-platform.md`:** adds step 8 with the mandatory per-application `cache:warmup` commands (flagged required on AWS/multi-container), cross-linking the architecture sections above.

Documents the gap behind [CC-39381](https://spryker.atlassian.net/browse/CC-39381) (suite PR spryker/suite#823 wires the warm-up into every API-generating install recipe).

[CC-39381]: https://spryker.atlassian.net/browse/CC-39381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
