### PR TITLE
CC-38802: Document configurable AI Commerce prompts

### DIFF
--- a/_data/sidebars/dg_dev_sidebar.yml
+++ b/_data/sidebars/dg_dev_sidebar.yml
@@ -78,6 +78,8 @@ entries:
             nested:
               - title: Install Back Office Assistant
                 url: /docs/dg/dev/ai/ai-commerce/backoffice-assistant/install-backoffice-assistant.html
+              - title: Add a custom Back Office Assistant agent
+                url: /docs/dg/dev/ai/ai-commerce/backoffice-assistant/add-custom-backoffice-assistant-agent.html
           - title: Search by Image
             url: /docs/dg/dev/ai/ai-commerce/search-by-image/search-by-image.html
             nested:

--- a/docs/dg/dev/ai/ai-commerce/backoffice-assistant/add-custom-backoffice-assistant-agent.md
+++ b/docs/dg/dev/ai/ai-commerce/backoffice-assistant/add-custom-backoffice-assistant-agent.md
@@ -1,0 +1,361 @@
+---
+title: Add a custom Back Office Assistant agent
+description: Learn how to implement and register a custom agent and toolset for the Back Office Assistant feature, including a dedicated AI configuration and SSE streaming.
+last_updated: Jul 09, 2026
+template: concept-topic-template
+---
+
+Back Office Assistant routes each conversation to the most appropriate agent through its intent router. To handle a new domain—for example, managing customers or CMS content—implement a custom agent and register it alongside the built-in agents described in [Back Office Assistant](/docs/dg/dev/ai/ai-commerce/backoffice-assistant/backoffice-assistant.html).
+
+## 1) Implement the agent plugin
+
+Create a plugin that implements `BackofficeAssistantAgentPluginInterface` from `SprykerFeature\Zed\AiCommerce\Dependency\BackofficeAssistant`:
+
+| METHOD | PURPOSE |
+|--------|---------|
+| `getName()` | Returns the unique agent name used for routing. This value is matched against the intent router's response. |
+| `getDescription()` | Describes what the agent handles. The intent router AI uses this description to decide which agent matches the user's request, so make it specific about the agent's domain and capabilities. |
+| `isApplicable()` | Returns whether the agent is available for routing. Use this to gate the agent behind a configuration flag, similar to the built-in agents. |
+| `executeAgent()` | Builds a `PromptRequestTransfer`, calls `AiFoundationFacade::prompt()`, and maps the result into a `BackofficeAssistantPromptResponseTransfer`. |
+
+```php
+<?php
+
+namespace Pyz\Zed\AiCommerce\Communication\Plugin\Agent;
+
+use Generated\Shared\Transfer\BackofficeAssistantPromptRequestTransfer;
+use Generated\Shared\Transfer\BackofficeAssistantPromptResponseTransfer;
+use Generated\Shared\Transfer\CustomerManagementAgentResponseTransfer;
+use Generated\Shared\Transfer\PromptMessageTransfer;
+use Generated\Shared\Transfer\PromptRequestTransfer;
+use Spryker\Shared\AiFoundation\AiFoundationConstants;
+use Spryker\Zed\Kernel\Communication\AbstractPlugin;
+use SprykerFeature\Zed\AiCommerce\Dependency\BackofficeAssistant\BackofficeAssistantAgentPluginInterface;
+
+/**
+ * @method \Pyz\Zed\AiCommerce\Communication\AiCommerceCommunicationFactory getFactory()
+ * @method \Pyz\Zed\AiCommerce\AiCommerceConfig getConfig()
+ */
+class CustomerManagementAgentPlugin extends AbstractPlugin implements BackofficeAssistantAgentPluginInterface
+{
+    protected const string NAME = 'Customer Management';
+
+    protected const string TOOL_SET_CUSTOMER_MANAGEMENT = 'customer_management_tools';
+
+    public function getName(): string
+    {
+        return static::NAME;
+    }
+
+    public function getDescription(): string
+    {
+        return 'Answers questions about customer accounts, addresses, and status. Use for customer lookup and account management questions.';
+    }
+
+    public function isApplicable(
+        BackofficeAssistantPromptRequestTransfer $backofficeAssistantPromptRequest,
+    ): bool {
+        return $this->getConfig()->isCustomerManagementAgentEnabled();
+    }
+
+    public function executeAgent(
+        BackofficeAssistantPromptRequestTransfer $backofficeAssistantPromptRequest,
+    ): BackofficeAssistantPromptResponseTransfer {
+        $promptRequest = (new PromptRequestTransfer())
+            ->setAiConfigurationName($this->getConfig()->getCustomerManagementAgentAiConfigurationName())
+            ->setConversationReference($backofficeAssistantPromptRequest->getConversationReference())
+            ->setStructuredMessage(new CustomerManagementAgentResponseTransfer())
+            ->addToolSetName(static::TOOL_SET_CUSTOMER_MANAGEMENT)
+            ->setPromptMessage(
+                (new PromptMessageTransfer())
+                    ->setType(AiFoundationConstants::MESSAGE_TYPE_USER)
+                    ->setContent($backofficeAssistantPromptRequest->getPrompt())
+                    ->setAttachments($backofficeAssistantPromptRequest->getAttachments()),
+            );
+
+        $promptResponse = $this->getFactory()->getAiFoundationFacade()->prompt($promptRequest);
+
+        $backofficeAssistantPromptResponse = new BackofficeAssistantPromptResponseTransfer();
+
+        if (!$promptResponse->getIsSuccessful()) {
+            return $backofficeAssistantPromptResponse;
+        }
+
+        /** @var \Generated\Shared\Transfer\CustomerManagementAgentResponseTransfer $customerManagementAgentResponse */
+        $customerManagementAgentResponse = $promptResponse->getStructuredMessage();
+
+        $backofficeAssistantPromptResponse->setAgent($customerManagementAgentResponse->getAgent());
+        $backofficeAssistantPromptResponse->setMessage($customerManagementAgentResponse->getMessage());
+        $backofficeAssistantPromptResponse->setReasoningMessage($customerManagementAgentResponse->getReasoningMessage());
+
+        return $backofficeAssistantPromptResponse;
+    }
+}
+```
+
+{% info_block infoBox "Info" %}
+
+The `CustomerManagementAgentResponseTransfer` structured message transfer, the `isCustomerManagementAgentEnabled()` and `getCustomerManagementAgentAiConfigurationName()` config methods, and the `customer_management_tools` toolset are project-specific and must be defined as part of this implementation. Model the response transfer on the existing `GeneralAgentResponseTransfer` or `DiscountManagementAgentResponseTransfer` structure, with `agent`, `message`, and `reasoningMessage` fields.
+
+{% endinfo_block %}
+
+## 2) Implement the toolset plugin
+
+Each agent resolves its tools through a named toolset. Create a plugin that implements `ToolSetPluginInterface` from `Spryker\Zed\AiFoundation\Dependency\Tools`:
+
+```php
+<?php
+
+namespace Pyz\Zed\AiCommerce\Communication\Plugin\AiFoundation;
+
+use Spryker\Zed\AiFoundation\Dependency\Tools\ToolSetPluginInterface;
+use Spryker\Zed\Kernel\Communication\AbstractPlugin;
+
+/**
+ * @method \Pyz\Zed\AiCommerce\Communication\AiCommerceCommunicationFactory getFactory()
+ */
+class CustomerManagementToolSetPlugin extends AbstractPlugin implements ToolSetPluginInterface
+{
+    protected const string TOOL_SET_CUSTOMER_MANAGEMENT = 'customer_management_tools';
+
+    public function getName(): string
+    {
+        return static::TOOL_SET_CUSTOMER_MANAGEMENT;
+    }
+
+    /**
+     * @return array<\Spryker\Zed\AiFoundation\Dependency\Tools\ToolPluginInterface>
+     */
+    public function getTools(): array
+    {
+        return [
+            $this->getFactory()->createGetCustomerDetailsToolPlugin(),
+        ];
+    }
+}
+```
+
+Each tool referenced in `getTools()` implements `ToolPluginInterface` from `Spryker\Zed\AiFoundation\Dependency\Tools`, exposing `getName()`, `getDescription()`, `getParameters()`, and `execute()`. The AI model uses `getName()` and `getDescription()` to decide when to call the tool, and `getParameters()` to know which arguments to pass.
+
+## 3) Register the plugins
+
+Register the agent plugin in `AiCommerceDependencyProvider::getBackofficeAssistantAgentPlugins()`, alongside the built-in agents:
+
+**src/Pyz/Zed/AiCommerce/AiCommerceDependencyProvider.php**
+
+```php
+<?php
+
+namespace Pyz\Zed\AiCommerce;
+
+use Pyz\Zed\AiCommerce\Communication\Plugin\Agent\CustomerManagementAgentPlugin;
+use SprykerFeature\Zed\AiCommerce\AiCommerceDependencyProvider as SprykerFeatureAiCommerceDependencyProvider;
+use SprykerFeature\Zed\AiCommerce\Communication\Plugin\Agent\DiscountManagementAgentPlugin;
+use SprykerFeature\Zed\AiCommerce\Communication\Plugin\Agent\FormFillAgentPlugin;
+use SprykerFeature\Zed\AiCommerce\Communication\Plugin\Agent\GeneralAgentPlugin;
+use SprykerFeature\Zed\AiCommerce\Communication\Plugin\Agent\OrderManagementAgentPlugin;
+
+class AiCommerceDependencyProvider extends SprykerFeatureAiCommerceDependencyProvider
+{
+    /**
+     * @return array<\SprykerFeature\Zed\AiCommerce\Dependency\BackofficeAssistant\BackofficeAssistantAgentPluginInterface>
+     */
+    protected function getBackofficeAssistantAgentPlugins(): array
+    {
+        return [
+            new GeneralAgentPlugin(),
+            new OrderManagementAgentPlugin(),
+            new DiscountManagementAgentPlugin(),
+            new FormFillAgentPlugin(),
+            new CustomerManagementAgentPlugin(),
+        ];
+    }
+}
+```
+
+Register the toolset plugin in `AiFoundationDependencyProvider::getAiToolSetPlugins()`:
+
+**src/Pyz/Zed/AiFoundation/AiFoundationDependencyProvider.php**
+
+```php
+<?php
+
+namespace Pyz\Zed\AiFoundation;
+
+use Pyz\Zed\AiCommerce\Communication\Plugin\AiFoundation\CustomerManagementToolSetPlugin;
+use Spryker\Zed\AiFoundation\AiFoundationDependencyProvider as SprykerAiFoundationDependencyProvider;
+use SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation\DiscountManagementToolSetPlugin;
+use SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation\FormFillToolSetPlugin;
+use SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation\NavigationToolSetPlugin;
+use SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation\OrderDetailsToolSetPlugin;
+use SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation\OrderManagementToolSetPlugin;
+
+class AiFoundationDependencyProvider extends SprykerAiFoundationDependencyProvider
+{
+    /**
+     * @return array<\Spryker\Zed\AiFoundation\Dependency\Tools\ToolSetPluginInterface>
+     */
+    protected function getAiToolSetPlugins(): array
+    {
+        return [
+            new NavigationToolSetPlugin(),
+            new OrderManagementToolSetPlugin(),
+            new OrderDetailsToolSetPlugin(),
+            new DiscountManagementToolSetPlugin(),
+            new FormFillToolSetPlugin(),
+            new CustomerManagementToolSetPlugin(),
+        ];
+    }
+}
+```
+
+## 4) Add a dedicated AI configuration
+
+Built-in Back Office Assistant agents share one Back Office setting, **AI Commerce > Back Office Assistant > AI Vendor**, that lets a project pick OpenAI, AWS Bedrock, or Anthropic for all agents at once. Each agent then resolves to a dedicated, per-provider named AI configuration for that choice. Follow the same pattern for a new agent so it participates in the same vendor switch and gets its own entries in the `AiFoundation` audit log.
+
+### 4.1) Define configuration key constants
+
+Add project-level constants for the new agent's per-provider configuration names and its model settings in `Pyz\Shared\AiCommerce\AiCommerceConstants`:
+
+**src/Pyz/Shared/AiCommerce/AiCommerceConstants.php**
+
+```php
+<?php
+
+namespace Pyz\Shared\AiCommerce;
+
+use SprykerFeature\Shared\AiCommerce\AiCommerceConstants as SprykerFeatureAiCommerceConstants;
+
+interface AiCommerceConstants extends SprykerFeatureAiCommerceConstants
+{
+    public const string AI_CONFIGURATION_CUSTOMER_MANAGEMENT_OPENAI = 'AI_COMMERCE:AI_CONFIGURATION_CUSTOMER_MANAGEMENT_OPENAI';
+
+    public const string AI_CONFIGURATION_CUSTOMER_MANAGEMENT_AWS = 'AI_COMMERCE:AI_CONFIGURATION_CUSTOMER_MANAGEMENT_AWS';
+
+    public const string AI_CONFIGURATION_CUSTOMER_MANAGEMENT_ANTHROPIC = 'AI_COMMERCE:AI_CONFIGURATION_CUSTOMER_MANAGEMENT_ANTHROPIC';
+}
+```
+
+### 4.2) Resolve the configuration name from `AiCommerceConfig`
+
+Override `AiCommerceConfig` in Zed to resolve the new agent's configuration name from the existing vendor setting, reusing `getBackofficeAssistantAiConfigurationName()`. This is the method referenced as `getCustomerManagementAgentAiConfigurationName()` in the agent plugin from step 1:
+
+**src/Pyz/Zed/AiCommerce/AiCommerceConfig.php**
+
+```php
+<?php
+
+namespace Pyz\Zed\AiCommerce;
+
+use Pyz\Shared\AiCommerce\AiCommerceConstants;
+use SprykerFeature\Zed\AiCommerce\AiCommerceConfig as SprykerFeatureAiCommerceConfig;
+
+class AiCommerceConfig extends SprykerFeatureAiCommerceConfig
+{
+    public function getCustomerManagementAgentAiConfigurationName(): ?string
+    {
+        return match ($this->getBackofficeAssistantAiConfigurationName()) {
+            AiCommerceConstants::AI_CONFIGURATION_BACKOFFICE_ASSISTANT_AWS => AiCommerceConstants::AI_CONFIGURATION_CUSTOMER_MANAGEMENT_AWS,
+            AiCommerceConstants::AI_CONFIGURATION_BACKOFFICE_ASSISTANT_ANTHROPIC => AiCommerceConstants::AI_CONFIGURATION_CUSTOMER_MANAGEMENT_ANTHROPIC,
+            default => AiCommerceConstants::AI_CONFIGURATION_CUSTOMER_MANAGEMENT_OPENAI,
+        };
+    }
+
+    public function isCustomerManagementAgentEnabled(): bool
+    {
+        return (bool)filter_var(
+            $this->getModuleConfig('ai_commerce:customer_management:general:is_enabled', true),
+            FILTER_VALIDATE_BOOLEAN,
+        );
+    }
+}
+```
+
+`getBackofficeAssistantAiConfigurationName()` and the `AI_CONFIGURATION_BACKOFFICE_ASSISTANT_*` constants already exist in the base `AiCommerceConfig`. Reuse them instead of adding a separate vendor switch for the new agent.
+
+### 4.3) Add the configuration entries
+
+Add one entry per provider to `config/Shared/config_ai.php`, following the same pattern used for the built-in agents in [Install Back Office Assistant](/docs/dg/dev/ai/ai-commerce/backoffice-assistant/install-backoffice-assistant.html#3-configure-ai-models-for-back-office-assistant). Reuse the existing `CONFIGURATION_KEY_BACKOFFICE_ASSISTANT_*_MODEL` and API token constants so the model and provider credentials stay configurable through Configuration Management, consistent with the other agents:
+
+**config/Shared/config_ai.php**
+
+```php
+<?php
+
+use Pyz\Shared\AiCommerce\AiCommerceConstants;
+use Spryker\Shared\AiFoundation\AiFoundationConstants;
+
+$config[AiFoundationConstants::AI_CONFIGURATIONS][AiCommerceConstants::AI_CONFIGURATION_CUSTOMER_MANAGEMENT_OPENAI] = [
+    'provider_name' => AiFoundationConstants::PROVIDER_OPENAI,
+    'provider_config' => [
+        'key' => AiFoundationConstants::CONFIGURATION_REFERENCE_PREFIX . AiCommerceConstants::CONFIGURATION_KEY_OPENAI_API_TOKEN,
+        'model' => AiFoundationConstants::CONFIGURATION_REFERENCE_PREFIX . AiCommerceConstants::CONFIGURATION_KEY_BACKOFFICE_ASSISTANT_OPENAI_MODEL,
+    ],
+];
+
+$config[AiFoundationConstants::AI_CONFIGURATIONS][AiCommerceConstants::AI_CONFIGURATION_CUSTOMER_MANAGEMENT_AWS] = [
+    'provider_name' => AiFoundationConstants::PROVIDER_BEDROCK,
+    'provider_config' => [
+        'model' => AiFoundationConstants::CONFIGURATION_REFERENCE_PREFIX . AiCommerceConstants::CONFIGURATION_KEY_BACKOFFICE_ASSISTANT_AWS_MODEL,
+        'bedrockRuntimeClient' => [
+            'region' => AiFoundationConstants::CONFIGURATION_REFERENCE_PREFIX . AiCommerceConstants::CONFIGURATION_KEY_AWS_REGION,
+            'token' => AiFoundationConstants::CONFIGURATION_REFERENCE_PREFIX . AiCommerceConstants::CONFIGURATION_KEY_AWS_API_TOKEN,
+        ],
+    ],
+];
+
+$config[AiFoundationConstants::AI_CONFIGURATIONS][AiCommerceConstants::AI_CONFIGURATION_CUSTOMER_MANAGEMENT_ANTHROPIC] = [
+    'provider_name' => AiFoundationConstants::PROVIDER_ANTHROPIC,
+    'provider_config' => [
+        'key' => AiFoundationConstants::CONFIGURATION_REFERENCE_PREFIX . AiCommerceConstants::CONFIGURATION_KEY_ANTHROPIC_API_TOKEN,
+        'model' => AiFoundationConstants::CONFIGURATION_REFERENCE_PREFIX . AiCommerceConstants::CONFIGURATION_KEY_BACKOFFICE_ASSISTANT_ANTHROPIC_MODEL,
+    ],
+];
+```
+
+{% info_block infoBox "Info" %}
+
+If the new agent needs its own model choice independent of the other agents, define dedicated `CONFIGURATION_KEY_CUSTOMER_MANAGEMENT_*_MODEL` constants and Configuration Management settings instead of reusing `CONFIGURATION_KEY_BACKOFFICE_ASSISTANT_*_MODEL`.
+
+{% endinfo_block %}
+
+## 5) Enable SSE streaming for the new agent
+
+Back Office Assistant streams tool call progress to the chat widget over Server-Sent Events. `BackofficeAssistantSsePreToolCallPlugin` and `BackofficeAssistantSsePostToolCallPlugin` only emit an event when the current prompt's AI configuration name is present in `AiCommerceConfig::getBackofficeAssistantSseAiConfigurationNames()`. If the new agent's configuration name is missing from that list, its tool calls run normally but their progress does not stream to the widget.
+
+Override `getBackofficeAssistantSseAiConfigurationNames()` in the project's `AiCommerceConfig` to include the new agent's configuration name:
+
+**src/Pyz/Zed/AiCommerce/AiCommerceConfig.php**
+
+```php
+<?php
+
+namespace Pyz\Zed\AiCommerce;
+
+use Pyz\Shared\AiCommerce\AiCommerceConstants;
+use SprykerFeature\Zed\AiCommerce\AiCommerceConfig as SprykerFeatureAiCommerceConfig;
+
+class AiCommerceConfig extends SprykerFeatureAiCommerceConfig
+{
+    // ... getCustomerManagementAgentAiConfigurationName() and isCustomerManagementAgentEnabled() from step 4.2
+
+    /**
+     * @return array<string>
+     */
+    public function getBackofficeAssistantSseAiConfigurationNames(): array
+    {
+        return array_values(array_filter([
+            ...parent::getBackofficeAssistantSseAiConfigurationNames(),
+            $this->getCustomerManagementAgentAiConfigurationName(),
+        ]));
+    }
+}
+```
+
+`BackofficeAssistantSsePreToolCallPlugin` and `BackofficeAssistantSsePostToolCallPlugin` are registered once in `AiFoundationDependencyProvider::getPreToolCallPlugins()` and `getPostToolCallPlugins()`, as shown in [Install Back Office Assistant](/docs/dg/dev/ai/ai-commerce/backoffice-assistant/install-backoffice-assistant.html#4-set-up-behavior). They apply to every agent whose configuration name is in the list above, so no additional plugin registration is required for the new agent.
+
+{% info_block warningBox "Verification" %}
+
+In the Back Office, open the Back Office Assistant chat widget and send a message that matches the new agent's description. Confirm the intent router routes the request to the new agent, that tool call progress streams live in the widget, and that the response uses the expected tools.
+
+{% endinfo_block %}

--- a/docs/dg/dev/ai/ai-commerce/backoffice-assistant/add-custom-backoffice-assistant-agent.md
+++ b/docs/dg/dev/ai/ai-commerce/backoffice-assistant/add-custom-backoffice-assistant-agent.md
@@ -1,7 +1,7 @@
 ---
 title: Add a custom Back Office Assistant agent
 description: Learn how to implement and register a custom agent and toolset for the Back Office Assistant feature, including a dedicated AI configuration and SSE streaming.
-last_updated: Jul 09, 2026
+last_updated: Jul 10, 2026
 template: concept-topic-template
 ---
 
@@ -139,21 +139,12 @@ Each tool referenced in `getTools()` implements `ToolPluginInterface` from `Spry
 
 ## 3) Register the plugins
 
-Register the agent plugin in `AiCommerceDependencyProvider::getBackofficeAssistantAgentPlugins()`, alongside the built-in agents:
+Add the agent plugin to the array returned by `AiCommerceDependencyProvider::getBackofficeAssistantAgentPlugins()`, alongside the already-registered built-in agents described in [Install Back Office Assistant](/docs/dg/dev/ai/ai-commerce/backoffice-assistant/install-backoffice-assistant.html#4-set-up-behavior):
 
 **src/Pyz/Zed/AiCommerce/AiCommerceDependencyProvider.php**
 
 ```php
-<?php
-
-namespace Pyz\Zed\AiCommerce;
-
 use Pyz\Zed\AiCommerce\Communication\Plugin\Agent\CustomerManagementAgentPlugin;
-use SprykerFeature\Zed\AiCommerce\AiCommerceDependencyProvider as SprykerFeatureAiCommerceDependencyProvider;
-use SprykerFeature\Zed\AiCommerce\Communication\Plugin\Agent\DiscountManagementAgentPlugin;
-use SprykerFeature\Zed\AiCommerce\Communication\Plugin\Agent\FormFillAgentPlugin;
-use SprykerFeature\Zed\AiCommerce\Communication\Plugin\Agent\GeneralAgentPlugin;
-use SprykerFeature\Zed\AiCommerce\Communication\Plugin\Agent\OrderManagementAgentPlugin;
 
 class AiCommerceDependencyProvider extends SprykerFeatureAiCommerceDependencyProvider
 {
@@ -163,32 +154,19 @@ class AiCommerceDependencyProvider extends SprykerFeatureAiCommerceDependencyPro
     protected function getBackofficeAssistantAgentPlugins(): array
     {
         return [
-            new GeneralAgentPlugin(),
-            new OrderManagementAgentPlugin(),
-            new DiscountManagementAgentPlugin(),
-            new FormFillAgentPlugin(),
+            // ... existing agent plugins
             new CustomerManagementAgentPlugin(),
         ];
     }
 }
 ```
 
-Register the toolset plugin in `AiFoundationDependencyProvider::getAiToolSetPlugins()`:
+Add the toolset plugin to the array returned by `AiFoundationDependencyProvider::getAiToolSetPlugins()`:
 
 **src/Pyz/Zed/AiFoundation/AiFoundationDependencyProvider.php**
 
 ```php
-<?php
-
-namespace Pyz\Zed\AiFoundation;
-
 use Pyz\Zed\AiCommerce\Communication\Plugin\AiFoundation\CustomerManagementToolSetPlugin;
-use Spryker\Zed\AiFoundation\AiFoundationDependencyProvider as SprykerAiFoundationDependencyProvider;
-use SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation\DiscountManagementToolSetPlugin;
-use SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation\FormFillToolSetPlugin;
-use SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation\NavigationToolSetPlugin;
-use SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation\OrderDetailsToolSetPlugin;
-use SprykerFeature\Zed\AiCommerce\Communication\Plugin\AiFoundation\OrderManagementToolSetPlugin;
 
 class AiFoundationDependencyProvider extends SprykerAiFoundationDependencyProvider
 {
@@ -198,11 +176,7 @@ class AiFoundationDependencyProvider extends SprykerAiFoundationDependencyProvid
     protected function getAiToolSetPlugins(): array
     {
         return [
-            new NavigationToolSetPlugin(),
-            new OrderManagementToolSetPlugin(),
-            new OrderDetailsToolSetPlugin(),
-            new DiscountManagementToolSetPlugin(),
-            new FormFillToolSetPlugin(),
+            // ... existing toolset plugins
             new CustomerManagementToolSetPlugin(),
         ];
     }

--- a/docs/dg/dev/ai/ai-commerce/backoffice-assistant/backoffice-assistant.md
+++ b/docs/dg/dev/ai/ai-commerce/backoffice-assistant/backoffice-assistant.md
@@ -1,7 +1,7 @@
 ---
 title: Back Office Assistant
 description: Technical overview of the Back Office Assistant feature — architecture, agents, AiFoundation integration, and configuration options.
-last_updated: Mar 31, 2026
+last_updated: Jul 09, 2026
 template: concept-topic-template
 ---
 
@@ -28,7 +28,7 @@ Back Office Assistant ships with four built-in agents:
 | Discount Management | `DiscountManagementAgentPlugin` | Creates and updates discounts through the Back Office API. |
 | Form Fill | `FormFillAgentPlugin` | Fills Back Office forms using natural language instructions. |
 
-Agents are registered in `AiCommerceDependencyProvider::getBackofficeAssistantAgentPlugins()`.
+Agents are registered in `AiCommerceDependencyProvider::getBackofficeAssistantAgentPlugins()`. To implement and register a custom agent, see [Add a custom Back Office Assistant agent](/docs/dg/dev/ai/ai-commerce/backoffice-assistant/add-custom-backoffice-assistant-agent.html).
 
 ## Toolsets
 

--- a/docs/dg/dev/ai/ai-commerce/backoffice-assistant/install-backoffice-assistant.md
+++ b/docs/dg/dev/ai/ai-commerce/backoffice-assistant/install-backoffice-assistant.md
@@ -86,7 +86,7 @@ Using a dedicated AI model configuration per agent is recommended because each n
 
 ### 4) Set up behavior
 
-Register the following plugins to integrate the Back Office Assistant agents:
+Register the following plugins to integrate the Back Office Assistant agents. To add a new agent instead of, or in addition to, the built-in ones, see [Add a custom Back Office Assistant agent](/docs/dg/dev/ai/ai-commerce/backoffice-assistant/add-custom-backoffice-assistant-agent.html).
 
 | PLUGIN | SPECIFICATION | PREREQUISITES | NAMESPACE |
 |--------|---------------|---------------|-----------|

--- a/docs/dg/dev/ai/ai-commerce/search-by-image/search-by-image.md
+++ b/docs/dg/dev/ai/ai-commerce/search-by-image/search-by-image.md
@@ -1,7 +1,7 @@
 ---
 title: Search by Image
 description: Technical overview of the Search by Image feature — architecture, AiFoundation integration, configuration options, and plugin structure.
-last_updated: Apr 10, 2026
+last_updated: Jul 08, 2026
 template: concept-topic-template
 ---
 
@@ -37,6 +37,16 @@ The following options can be configured at the project level in `AiCommerceConfi
 | `getSearchByImageMaxFileSizeInBytes()` | Defined in `AiCommerceConfig` | Maximum upload file size in bytes. |
 | `getSearchByImageAiConfigurationName()` | `null` | Named AI model configuration identifier used to look up the provider config from `AiFoundation`. When `null`, the default configuration is used. |
 | `getSearchByImageRedirectType()` | `search_results` | Controls the redirect target after a successful image search. Controlled via the Back Office. |
+
+## System prompt
+
+The prompt used to identify the main product in an uploaded image and return a search term is managed in the Back Office under **AI Commerce > Search by Image > System Prompts**. The default prompt is defined in `ai_commerce.configuration.yml` and can be customized per environment through the configuration UI or a project configuration file, without a code change.
+
+| CONFIGURATION KEY | DESCRIPTION |
+|--------------------|-------------|
+| `AiCommerceConstants::CONFIGURATION_KEY_SEARCH_BY_IMAGE_PROMPT` | Prompt used to identify the main product in an uploaded image and return a relevant search term. |
+
+If the overridden prompt is blank or contains only whitespace, Search by Image falls back to the default prompt instead of sending an empty value to the AI provider.
 
 ## Install
 

--- a/docs/dg/dev/ai/ai-commerce/smart-pim/smart-pim.md
+++ b/docs/dg/dev/ai/ai-commerce/smart-pim/smart-pim.md
@@ -1,7 +1,7 @@
 ---
 title: Smart PIM
 description: Technical overview of the Smart PIM feature — architecture, AiFoundation integration, plugin structure, and configuration options.
-last_updated: Apr 27, 2026
+last_updated: Jul 08, 2026
 template: concept-topic-template
 ---
 
@@ -25,6 +25,20 @@ Category suggestion requires the `ProductCategoryAbstractFormExpanderPlugin` to 
 | Image alt text | `getImageAltTextAiConfigurationName()` | Generates descriptive alt text for product images. |
 | Category suggestion | `getCategorySuggestionAiConfigurationName()` | Suggests relevant product categories based on product content. |
 | Translation | `getTranslationAiConfigurationName()` | Translates product content into configured store languages. |
+
+## System prompts
+
+Each Smart PIM capability uses its own prompt template, managed in the Back Office under **AI Commerce > Smart PIM > System Prompts**. The default prompts are defined in `ai_commerce.configuration.yml` and can be customized per environment through the configuration UI or a project configuration file, without a code change.
+
+| CAPABILITY | CONFIGURATION KEY | DESCRIPTION |
+|------------|--------------------|-------------|
+| Content improvement | `AiCommerceConstants::CONFIGURATION_KEY_SMART_PIM_CONTENT_IMPROVER_PROMPT` | Prompt used to improve product content. Keeps the `%s` placeholder for the text to improve. |
+| Translation | `AiCommerceConstants::CONFIGURATION_KEY_SMART_PIM_TRANSLATION_PROMPT` | Prompt used to translate product content. Keeps the `%s` placeholders for the text, source locale, and target locale. |
+| Translation collection | `AiCommerceConstants::CONFIGURATION_KEY_SMART_PIM_TRANSLATION_COLLECTION_PROMPT` | Prompt used to translate product content into a collection of locales in a single request. Keeps the `%s` placeholders for the text, source locale, and target locales. |
+| Category suggestion | `AiCommerceConstants::CONFIGURATION_KEY_SMART_PIM_CATEGORY_SUGGESTION_PROMPT` | Prompt used to suggest product categories. Keeps the `%s` placeholders for the product name, description, and existing categories. |
+| Image alt text | `AiCommerceConstants::CONFIGURATION_KEY_SMART_PIM_IMAGE_ALT_TEXT_PROMPT` | Prompt used to generate alt text for a product image. Keeps the `%s` placeholder for the locale. |
+
+If an overridden prompt is blank or contains only whitespace, Smart PIM falls back to the default prompt instead of sending an empty value to the AI provider.
 
 ## Install
 

--- a/docs/dg/dev/ai/ai-commerce/visual-add-to-cart/visual-add-to-cart.md
+++ b/docs/dg/dev/ai/ai-commerce/visual-add-to-cart/visual-add-to-cart.md
@@ -1,7 +1,7 @@
 ---
 title: Visual Add to Cart
 description: Technical overview of the Visual Add to Cart feature — architecture, AiFoundation integration, configuration options, and plugin structure.
-last_updated: Mar 31, 2026
+last_updated: Jul 08, 2026
 template: concept-topic-template
 ---
 
@@ -37,6 +37,16 @@ The following options can be configured at the project level in `AiCommerceConfi
 | `getQuickOrderImageToCartMaxProducts()` | `20` | Maximum number of products recognized per image. |
 | `getQuickOrderImageToCartTextSimilarityThresholdPercent()` | `30` | Minimum word-overlap percentage required to consider a catalog match valid. |
 | `getQuickOrderImageToCartAiConfigurationName()` | `null` | Named AI model configuration identifier used to look up the provider config from `AiFoundation`. When `null`, the default configuration is used. |
+
+## System prompt
+
+The prompt used to recognize products from an uploaded image on the Quick Order page is managed in the Back Office under **AI Commerce > Quick Order > System Prompts**. The default prompt is defined in `ai_commerce.configuration.yml` and can be customized per environment through the configuration UI or a project configuration file, without a code change.
+
+| CONFIGURATION KEY | DESCRIPTION |
+|--------------------|-------------|
+| `AiCommerceConstants::CONFIGURATION_KEY_QUICK_ORDER_IMAGE_RECOGNITION_PROMPT` | Prompt used to recognize products and quantities from an uploaded image. Keeps the `%s` placeholder for the current store locale. |
+
+If the overridden prompt is blank or contains only whitespace, Visual Add to Cart falls back to the default prompt instead of sending an empty value to the AI provider.
 
 ## Install
 


### PR DESCRIPTION
## Summary

Documents that the Smart PIM, Search by Image, and Visual Add to Cart prompts are now configurable via Spryker Configuration Management (project config file or Back Office Configuration UI), instead of being hardcoded/only overridable through vendor code.

## Related

- Implementation PR: https://github.com/spryker/suite/pull/889
- Ticket: [CC-38802](https://spryker.atlassian.net/browse/CC-38802)

## Changes

- `docs/dg/dev/ai/ai-commerce/smart-pim/smart-pim.md` — added a "System prompts" section documenting the 5 configurable Smart PIM prompt keys (content improver, translation, translation collection, category suggestion, image alt text) and the blank-value fallback behavior.
- `docs/dg/dev/ai/ai-commerce/search-by-image/search-by-image.md` — added a "System prompt" section documenting the configurable search-term prompt key and fallback behavior.
- `docs/dg/dev/ai/ai-commerce/visual-add-to-cart/visual-add-to-cart.md` — added a "System prompt" section documenting the configurable image-recognition prompt key (including the locale placeholder) and fallback behavior.

All three sections mirror the existing "System prompts" pattern already documented for Back Office Assistant.

[CC-38802]: https://spryker.atlassian.net/browse/CC-38802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ