### PR TITLE
Restrict Context7 widget to allowed domains

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,7 +42,23 @@
 
     {% include google_analytics.html %}
 
-    <script src="https://context7.com/widget.js" data-library="/spryker/spryker-docs" data-color="#1ebea0" data-position="bottom-right" data-placeholder="Ask about Spryker..."></script>
+    <script>
+        (function () {
+            var hostname = window.location.hostname;
+            var allowedHosts = ['docs.spryker.com', 'localhost', '0.0.0.0'];
+            var isAllowed = allowedHosts.indexOf(hostname) !== -1 || hostname.endsWith('.netlify.app');
+            if (!isAllowed) {
+                return;
+            }
+            var script = document.createElement('script');
+            script.src = 'https://context7.com/widget.js';
+            script.setAttribute('data-library', '/spryker/spryker-docs');
+            script.setAttribute('data-color', '#1ebea0');
+            script.setAttribute('data-position', 'bottom-right');
+            script.setAttribute('data-placeholder', 'Ask about Spryker...');
+            document.body.appendChild(script);
+        })();
+    </script>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- The Context7 chat widget script (`_layouts/default.html`) loaded unconditionally, and Context7 does not enforce its own domain allowlist client-side — the widget was rendering on non-whitelisted domains such as `docs-archive.spryker.com`.
- Wrapped the script injection in a client-side host check so the widget only loads on `docs.spryker.com`, `localhost`, `0.0.0.0`, and `*.netlify.app` preview domains.

## Test plan
- [x] Verified via Chrome DevTools that the widget rendered on `docs-archive.spryker.com` (non-whitelisted) before the fix.
- [x] Ran the site locally via `docker compose up` (Jekyll on `localhost:4000`) and confirmed the widget now appears (network request to `context7.com/widget.js` returns 200, widget bubble visible).
- [x] Confirmed the guard logic correctly allows `docs.spryker.com`, `localhost`, `0.0.0.0`, `*.netlify.app`, and blocks all other hostnames.