### PR TITLE
CC-39773: Document spryker-bugfix skill in AI Dev SDK docs

### DIFF
--- a/docs/dg/dev/ai/ai-dev/ai-dev-claude-code-plugin.md
+++ b/docs/dg/dev/ai/ai-dev/ai-dev-claude-code-plugin.md
@@ -1,7 +1,7 @@
 ---
 title: Claude Code Plugin
 description: Install and use the Spryker AI Dev SDK plugin for Claude Code to get Spryker-aware skills, code review, and project setup directly in your AI coding assistant.
-last_updated: Jun 22, 2026
+last_updated: Jul 22, 2026
 label: early-access
 keywords: ai, claude, claude code, plugin, marketplace, skills, spryker, ai-dev, code review
 template: howto-guide-template
@@ -105,6 +105,7 @@ The plugin bundles the following Spryker-aware skills. Invoke them in Claude Cod
 | Yves Atomic Frontend | `/spryker-ai-dev-sdk:yves-atomic-frontend` | Helps create atomic design components for the Yves frontend |
 | Product Requirement Document | `/spryker-ai-dev-sdk:product-requirement-document` | Drafts a research-grounded product requirement document for a Spryker feature before implementation |
 | Spryker Customization | `/spryker-ai-dev-sdk:spryker-customization` | Orchestrates the end-to-end build of a customization from product requirement document to committed branch |
+| Spryker Bugfix | `/spryker-ai-dev-sdk:spryker-bugfix` | Orchestrates the end-to-end bug fix from a ticket or description to a committed, validated, QA-accepted branch (Autonomous mode adds a pushed Draft PR with a CI watch loop) |
 | Spryker Refresher | `/spryker-ai-dev-sdk:spryker-refresher` | Runs the right post-change console and composer commands after edits |
 | Spryker QA Coverage | `/spryker-ai-dev-sdk:spryker-qa-coverage` | Turns acceptance criteria into a four-bucket test plan and executes it against the running app |
 | Spryker Docs Research | `/spryker-ai-dev-sdk:spryker-docs-research` | Looks up grounded answers in the official Spryker documentation |

--- a/docs/dg/dev/ai/ai-dev/ai-dev-skills-and-agents.md
+++ b/docs/dg/dev/ai/ai-dev/ai-dev-skills-and-agents.md
@@ -1,7 +1,7 @@
 ---
 title: AI Dev SDK Skills and Agents
 description: Reference of the skills and agents shipped with the AI Dev SDK
-last_updated: Jun 22, 2026
+last_updated: Jul 22, 2026
 label: early-access
 keywords: ai, ai-dev, claude, claude code, windsurf, copilot, skills, agents, subagents, spryker
 template: concept-topic-template
@@ -55,6 +55,7 @@ Skills are delivered through `ai-dev:setup` (all supported AI tools) or the Clau
 | `yves-atomic-frontend` | Create atomic design components for the Yves storefront | Components match the project's atomic conventions |
 | `product-requirement-document` | Turn a feature idea into a research-grounded product requirement document before any code is written | Spec-before-code; assigns a real Spryker actor to every story; cuts ambiguity before implementation |
 | [`spryker-customization`](/docs/dg/dev/ai/ai-dev/ai-dev-customization-workflow.html) | Walk a product requirement document or set of acceptance criteria through to a committed branch | One workflow drives the full build; quality bar (PoC or MVP) chosen up-front; delegates focused work to the agents below; never auto-commits |
+| `spryker-bugfix` | Drive a bug from an optional tracker ticket or a plain description through to a committed, validated, QA-accepted fix | Orchestrates reproduce, root-cause, minimal fix, functional test, static validation, review, QA, and final verification; a shared attempt budget loops back on any failed gate; Autonomous mode adds a pushed Draft PR with a remote-CI watch loop |
 | `spryker-refresher` | Run the right post-change console and composer commands after edits | Owns the file-to-command mapping (codegen, caches, frontend builds, class-resolver); no missed cache rebuilds |
 | `spryker-qa-coverage` | Turn acceptance criteria into a four-bucket test plan executed against the live app | Coverage goes beyond literal ACs — happy / negative / authorization / corner cases; reports pass/fail with real evidence |
 | `spryker-docs-research` | Look up the right answer in official Spryker documentation | Grounds AI work in documented behavior rather than the model's memory; falls back gracefully when MCP tools are unavailable |


### PR DESCRIPTION
## Summary

Documents the new `spryker-bugfix` skill added to the AI Dev SDK plugin — an end-to-end, orchestrated bug-fixing workflow (reproduce → root-cause → minimal fix → functional tests → static validation → code review → independent QA → final verification, with an Autonomous mode that pushes a Draft PR and watches remote CI).

## Related

- Implementation PR: https://github.com/spryker-sdk/ai-dev/pull/25
- Ticket: https://spryker.atlassian.net/browse/CC-39773

## Changes

- **AI Dev SDK Skills and Agents** (`docs/dg/dev/ai/ai-dev/ai-dev-skills-and-agents.md`) — added `spryker-bugfix` to the Skills reference table.
- **Claude Code Plugin** (`docs/dg/dev/ai/ai-dev/ai-dev-claude-code-plugin.md`) — added the `/spryker-ai-dev-sdk:spryker-bugfix` slash command to the plugin Skills table.
- Bumped `last_updated` on both pages.