### PR TITLE
SUPESC-1131 Data import from BO is not working OOTB on the new enviroments

### DIFF
--- a/_includes/pbc/all/install-features/latest/install-the-ssp-asset-management-feature.md
+++ b/_includes/pbc/all/install-features/latest/install-the-ssp-asset-management-feature.md
@@ -55,6 +55,8 @@ Make sure the following packages are now listed in `composer.lock`:
 
 **config/Shared/config_default.php**
 
+To enable an IAM role configuration, use `IamAws3v3FilesystemBuilderPlugin`:
+
 ```php
 use Spryker\Shared\FileSystem\FileSystemConstants;
 use SprykerFeature\Shared\SelfServicePortal\SelfServicePortalConstants;
@@ -91,7 +93,7 @@ In cloud environments, set the following environment variables:
 
 {% endinfo_block %}
 
-Alternatively, to authenticate with explicit access keys instead of an IAM role, use `Aws3v3FilesystemBuilderPlugin`:
+Alternatively, to authenticate with explicit access keys, use `Aws3v3FilesystemBuilderPlugin`:
 
 ```php
 use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;

--- a/_includes/pbc/all/install-features/latest/install-the-ssp-asset-management-feature.md
+++ b/_includes/pbc/all/install-features/latest/install-the-ssp-asset-management-feature.md
@@ -81,36 +81,21 @@ $config[KernelConstants::CORE_NAMESPACES] = [
 ];
 ```
 
+{% info_block warningBox "IAM authentication required" %}
+
+These buckets authenticate through the IAM role attached to the workload. Access keys (`key` and `secret`) are not supported. If your project was set up from older documentation using access keys, migrate to this configuration. For more details, see [AWS S3 filesystem builder plugins](/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.html#aws-s3-filesystem-builder-plugins).
+
+{% endinfo_block %}
+
 {% info_block infoBox "Cloud environment variables" %}
 
 In cloud environments, set the following environment variables:
 
-- `SPRYKER_S3_SSP_ASSETS_KEY` - AWS S3 access key for SSP assets storage
-- `SPRYKER_S3_SSP_ASSETS_SECRET` - AWS S3 secret key for SSP assets storage
 - `SPRYKER_S3_SSP_ASSETS_BUCKET` - AWS S3 bucket name for SSP assets storage
 - `AWS_REGION` - AWS region
 - `SPRYKER_SSP_DEFAULT_FILE_MAX_SIZE` - Maximum file size for SSP asset uploads (defaults to `10M` if not set)
 
 {% endinfo_block %}
-
-Alternatively, to authenticate with explicit access keys, use `Aws3v3FilesystemBuilderPlugin`:
-
-```php
-use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;
-
-$config[FileSystemConstants::FILESYSTEM_SERVICE] = [
-    'ssp-asset-image' => [
-        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_SSP_ASSETS_KEY') ?: '',
-        'secret' => getenv('SPRYKER_S3_SSP_ASSETS_SECRET') ?: '',
-        'bucket' => getenv('SPRYKER_S3_SSP_ASSETS_BUCKET') ?: '',
-        'region' => getenv('AWS_REGION') ?: '',
-        'version' => 'latest',
-        'root' => '/ssp-asset-image',
-        'path' => '',
-    ],
-];
-```
 
 **src/Pyz/Zed/SelfServicePortal/SelfServicePortalConfig.php**
 

--- a/_includes/pbc/all/install-features/latest/install-the-ssp-asset-management-feature.md
+++ b/_includes/pbc/all/install-features/latest/install-the-ssp-asset-management-feature.md
@@ -63,13 +63,9 @@ use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\IamAws3v3Filesyst
 $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
     'ssp-asset-image' => [
         'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_SSP_ASSETS_KEY') ?: '',
-        'secret' => getenv('SPRYKER_S3_SSP_ASSETS_SECRET') ?: '',
         'bucket' => getenv('SPRYKER_S3_SSP_ASSETS_BUCKET') ?: '',
         'region' => getenv('AWS_REGION') ?: '',
-        'version' => 'latest',
-        'root' => '/ssp-asset-image',
-        'path' => '',
+        'path' => '/ssp-asset-image',
     ],
 ];
 
@@ -94,6 +90,25 @@ In cloud environments, set the following environment variables:
 - `SPRYKER_SSP_DEFAULT_FILE_MAX_SIZE` - Maximum file size for SSP asset uploads (defaults to `10M` if not set)
 
 {% endinfo_block %}
+
+Alternatively, to authenticate with explicit access keys instead of an IAM role, use `Aws3v3FilesystemBuilderPlugin`:
+
+```php
+use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;
+
+$config[FileSystemConstants::FILESYSTEM_SERVICE] = [
+    'ssp-asset-image' => [
+        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
+        'key' => getenv('SPRYKER_S3_SSP_ASSETS_KEY') ?: '',
+        'secret' => getenv('SPRYKER_S3_SSP_ASSETS_SECRET') ?: '',
+        'bucket' => getenv('SPRYKER_S3_SSP_ASSETS_BUCKET') ?: '',
+        'region' => getenv('AWS_REGION') ?: '',
+        'version' => 'latest',
+        'root' => '/ssp-asset-image',
+        'path' => '',
+    ],
+];
+```
 
 **src/Pyz/Zed/SelfServicePortal/SelfServicePortalConfig.php**
 

--- a/_includes/pbc/all/install-features/latest/install-the-ssp-asset-management-feature.md
+++ b/_includes/pbc/all/install-features/latest/install-the-ssp-asset-management-feature.md
@@ -58,11 +58,11 @@ Make sure the following packages are now listed in `composer.lock`:
 ```php
 use Spryker\Shared\FileSystem\FileSystemConstants;
 use SprykerFeature\Shared\SelfServicePortal\SelfServicePortalConstants;
-use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;
+use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\IamAws3v3FilesystemBuilderPlugin;
 
 $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
     'ssp-asset-image' => [
-        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
+        'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
         'key' => getenv('SPRYKER_S3_SSP_ASSETS_KEY') ?: '',
         'secret' => getenv('SPRYKER_S3_SSP_ASSETS_SECRET') ?: '',
         'bucket' => getenv('SPRYKER_S3_SSP_ASSETS_BUCKET') ?: '',

--- a/_includes/pbc/all/install-features/latest/install-the-ssp-file-management-feature.md
+++ b/_includes/pbc/all/install-features/latest/install-the-ssp-file-management-feature.md
@@ -48,6 +48,8 @@ Make sure the following modules have been installed:
 
 **config/Shared/config_default.php**
 
+To enable an IAM role configuration, use `IamAws3v3FilesystemBuilderPlugin`:
+
 ```php
 <?php
 
@@ -72,7 +74,7 @@ $config[KernelConstants::CORE_NAMESPACES] = [
 ];
 ```
 
-Alternatively, to authenticate with explicit access keys instead of an IAM role, use `Aws3v3FilesystemBuilderPlugin`:
+Alternatively, to authenticate with explicit access keys, use `Aws3v3FilesystemBuilderPlugin`:
 
 ```php
 use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;

--- a/_includes/pbc/all/install-features/latest/install-the-ssp-file-management-feature.md
+++ b/_includes/pbc/all/install-features/latest/install-the-ssp-file-management-feature.md
@@ -58,13 +58,9 @@ use SprykerFeature\Shared\SelfServicePortal\SelfServicePortalConstants;
 $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
     'ssp-files' => [
         'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_SSP_FILES_KEY') ?: '',
-        'secret' => getenv('SPRYKER_S3_SSP_FILES_SECRET') ?: '',
         'bucket' => getenv('SPRYKER_S3_SSP_FILES_BUCKET') ?: '',
         'region' => getenv('AWS_REGION') ?: '',
-        'version' => 'latest',
-        'root' => '/files',
-        'path' => '',
+        'path' => '/files',
     ],
 ];
 
@@ -73,6 +69,25 @@ $config[SelfServicePortalConstants::STORAGE_NAME] = 'ssp-files';
 $config[KernelConstants::CORE_NAMESPACES] = [
     ...
     'SprykerFeature',
+];
+```
+
+Alternatively, to authenticate with explicit access keys instead of an IAM role, use `Aws3v3FilesystemBuilderPlugin`:
+
+```php
+use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;
+
+$config[FileSystemConstants::FILESYSTEM_SERVICE] = [
+    'ssp-files' => [
+        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
+        'key' => getenv('SPRYKER_S3_SSP_FILES_KEY') ?: '',
+        'secret' => getenv('SPRYKER_S3_SSP_FILES_SECRET') ?: '',
+        'bucket' => getenv('SPRYKER_S3_SSP_FILES_BUCKET') ?: '',
+        'region' => getenv('AWS_REGION') ?: '',
+        'version' => 'latest',
+        'root' => '/files',
+        'path' => '',
+    ],
 ];
 ```
 

--- a/_includes/pbc/all/install-features/latest/install-the-ssp-file-management-feature.md
+++ b/_includes/pbc/all/install-features/latest/install-the-ssp-file-management-feature.md
@@ -52,12 +52,12 @@ Make sure the following modules have been installed:
 <?php
 
 use Spryker\Shared\FileSystem\FileSystemConstants;
-use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;
+use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\IamAws3v3FilesystemBuilderPlugin;
 use SprykerFeature\Shared\SelfServicePortal\SelfServicePortalConstants;
 
 $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
     'ssp-files' => [
-        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
+        'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
         'key' => getenv('SPRYKER_S3_SSP_FILES_KEY') ?: '',
         'secret' => getenv('SPRYKER_S3_SSP_FILES_SECRET') ?: '',
         'bucket' => getenv('SPRYKER_S3_SSP_FILES_BUCKET') ?: '',

--- a/_includes/pbc/all/install-features/latest/install-the-ssp-file-management-feature.md
+++ b/_includes/pbc/all/install-features/latest/install-the-ssp-file-management-feature.md
@@ -74,24 +74,11 @@ $config[KernelConstants::CORE_NAMESPACES] = [
 ];
 ```
 
-Alternatively, to authenticate with explicit access keys, use `Aws3v3FilesystemBuilderPlugin`:
+{% info_block warningBox "IAM authentication required" %}
 
-```php
-use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;
+These buckets authenticate through the IAM role attached to the workload. Access keys (`key` and `secret`) are not supported. If your project was set up from older documentation using access keys, migrate to this configuration. For more details, see [AWS S3 filesystem builder plugins](/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.html#aws-s3-filesystem-builder-plugins).
 
-$config[FileSystemConstants::FILESYSTEM_SERVICE] = [
-    'ssp-files' => [
-        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_SSP_FILES_KEY') ?: '',
-        'secret' => getenv('SPRYKER_S3_SSP_FILES_SECRET') ?: '',
-        'bucket' => getenv('SPRYKER_S3_SSP_FILES_BUCKET') ?: '',
-        'region' => getenv('AWS_REGION') ?: '',
-        'version' => 'latest',
-        'root' => '/files',
-        'path' => '',
-    ],
-];
-```
+{% endinfo_block %}
 
 ## Set up database schema
 

--- a/_includes/pbc/all/install-features/latest/install-the-ssp-inquiry-management-feature.md
+++ b/_includes/pbc/all/install-features/latest/install-the-ssp-inquiry-management-feature.md
@@ -90,37 +90,22 @@ $config[KernelConstants::CORE_NAMESPACES] = [
 ];
 ```
 
+{% info_block warningBox "IAM authentication required" %}
+
+These buckets authenticate through the IAM role attached to the workload. Access keys (`key` and `secret`) are not supported. If your project was set up from older documentation using access keys, migrate to this configuration. For more details, see [AWS S3 filesystem builder plugins](/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.html#aws-s3-filesystem-builder-plugins).
+
+{% endinfo_block %}
+
 {% info_block infoBox "Cloud environment variables" %}
 
 In cloud environments, set the following environment variables:
 
-- `SPRYKER_S3_SSP_INQUIRIES_KEY` - AWS S3 access key for SSP inquiry file storage
-- `SPRYKER_S3_SSP_INQUIRIES_SECRET` - AWS S3 secret key for SSP inquiry file storage
 - `SPRYKER_S3_SSP_INQUIRIES_BUCKET` - AWS S3 bucket name for SSP inquiry file storage
 - `AWS_REGION` - AWS region
 - `SPRYKER_DEFAULT_TOTAL_FILE_MAX_SIZE` - Maximum total size for all files uploaded with a single inquiry (defaults to `100M` if not set)
 - `SPRYKER_DEFAULT_FILE_MAX_SIZE` - Maximum size for a single file uploaded with an inquiry (defaults to `20M` if not set)
 
 {% endinfo_block %}
-
-Alternatively, to authenticate with explicit access keys, use `Aws3v3FilesystemBuilderPlugin`:
-
-```php
-use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;
-
-$config[FileSystemConstants::FILESYSTEM_SERVICE] = [
-    'ssp-inquiry' => [
-        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_SSP_INQUIRIES_KEY') ?: '',
-        'secret' => getenv('SPRYKER_S3_SSP_INQUIRIES_SECRET') ?: '',
-        'bucket' => getenv('SPRYKER_S3_SSP_INQUIRIES_BUCKET') ?: '',
-        'region' => getenv('AWS_REGION') ?: '',
-        'version' => 'latest',
-        'root' => '/ssp-inquiry',
-        'path' => '',
-    ],
-];
-```
 
 <details>
   <summary>src/Pyz/Shared/SelfServicePortal/SelfServicePortalConfig.php</summary>

--- a/_includes/pbc/all/install-features/latest/install-the-ssp-inquiry-management-feature.md
+++ b/_includes/pbc/all/install-features/latest/install-the-ssp-inquiry-management-feature.md
@@ -66,15 +66,15 @@ Make sure the following packages are now listed in `composer.lock`:
 
 use Spryker\Shared\FileSystem\FileSystemConstants;
 use SprykerFeature\Shared\SelfServicePortal\SelfServicePortalConstants;
-use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;
+use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\IamAws3v3FilesystemBuilderPlugin;
 
 $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
      'ssp-inquiry' => [
-        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_SSP_CLAIM_KEY') ?: '',
-        'secret' => getenv('SPRYKER_S3_SSP_CLAIM_SECRET') ?: '',
-        'bucket' => getenv('SPRYKER_S3_SSP_CLAIM_BUCKET') ?: '',
-        'region' => getenv('AWS_REGION') ?: '',
+        'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
+        'key' => getenv('SPRYKER_S3_SSP_INQUIRIES_KEY') ?: '',
+        'secret' => getenv('SPRYKER_S3_SSP_INQUIRIES_SECRET') ?: '',
+        'bucket' => getenv('SPRYKER_S3_SSP_INQUIRIES_BUCKET') ?: '',
+        'region' => $awsRegion,
         'version' => 'latest',
         'root' => '/ssp-inquiry',
         'path' => '',

--- a/_includes/pbc/all/install-features/latest/install-the-ssp-inquiry-management-feature.md
+++ b/_includes/pbc/all/install-features/latest/install-the-ssp-inquiry-management-feature.md
@@ -71,13 +71,9 @@ use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\IamAws3v3Filesyst
 $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
      'ssp-inquiry' => [
         'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_SSP_INQUIRIES_KEY') ?: '',
-        'secret' => getenv('SPRYKER_S3_SSP_INQUIRIES_SECRET') ?: '',
         'bucket' => getenv('SPRYKER_S3_SSP_INQUIRIES_BUCKET') ?: '',
-        'region' => $awsRegion,
-        'version' => 'latest',
-        'root' => '/ssp-inquiry',
-        'path' => '',
+        'region' => getenv('AWS_REGION') ?: '',
+        'path' => '/ssp-inquiry',
     ],
 ];
 
@@ -96,14 +92,33 @@ $config[KernelConstants::CORE_NAMESPACES] = [
 
 In cloud environments, set the following environment variables:
 
-- `SPRYKER_S3_SSP_CLAIM_KEY` - AWS S3 access key for SSP inquiry file storage
-- `SPRYKER_S3_SSP_CLAIM_SECRET` - AWS S3 secret key for SSP inquiry file storage
-- `SPRYKER_S3_SSP_CLAIM_BUCKET` - AWS S3 bucket name for SSP inquiry file storage
+- `SPRYKER_S3_SSP_INQUIRIES_KEY` - AWS S3 access key for SSP inquiry file storage
+- `SPRYKER_S3_SSP_INQUIRIES_SECRET` - AWS S3 secret key for SSP inquiry file storage
+- `SPRYKER_S3_SSP_INQUIRIES_BUCKET` - AWS S3 bucket name for SSP inquiry file storage
 - `AWS_REGION` - AWS region
 - `SPRYKER_DEFAULT_TOTAL_FILE_MAX_SIZE` - Maximum total size for all files uploaded with a single inquiry (defaults to `100M` if not set)
 - `SPRYKER_DEFAULT_FILE_MAX_SIZE` - Maximum size for a single file uploaded with an inquiry (defaults to `20M` if not set)
 
 {% endinfo_block %}
+
+Alternatively, to authenticate with explicit access keys instead of an IAM role, use `Aws3v3FilesystemBuilderPlugin`:
+
+```php
+use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;
+
+$config[FileSystemConstants::FILESYSTEM_SERVICE] = [
+    'ssp-inquiry' => [
+        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
+        'key' => getenv('SPRYKER_S3_SSP_INQUIRIES_KEY') ?: '',
+        'secret' => getenv('SPRYKER_S3_SSP_INQUIRIES_SECRET') ?: '',
+        'bucket' => getenv('SPRYKER_S3_SSP_INQUIRIES_BUCKET') ?: '',
+        'region' => getenv('AWS_REGION') ?: '',
+        'version' => 'latest',
+        'root' => '/ssp-inquiry',
+        'path' => '',
+    ],
+];
+```
 
 <details>
   <summary>src/Pyz/Shared/SelfServicePortal/SelfServicePortalConfig.php</summary>

--- a/_includes/pbc/all/install-features/latest/install-the-ssp-inquiry-management-feature.md
+++ b/_includes/pbc/all/install-features/latest/install-the-ssp-inquiry-management-feature.md
@@ -61,6 +61,8 @@ Make sure the following packages are now listed in `composer.lock`:
 
 **config/Shared/config_default.php**
 
+To enable an IAM role configuration, use `IamAws3v3FilesystemBuilderPlugin`:
+
 ```php
 <?php
 
@@ -101,7 +103,7 @@ In cloud environments, set the following environment variables:
 
 {% endinfo_block %}
 
-Alternatively, to authenticate with explicit access keys instead of an IAM role, use `Aws3v3FilesystemBuilderPlugin`:
+Alternatively, to authenticate with explicit access keys, use `Aws3v3FilesystemBuilderPlugin`:
 
 ```php
 use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;

--- a/_includes/pbc/all/install-features/latest/install-the-ssp-model-management-feature.md
+++ b/_includes/pbc/all/install-features/latest/install-the-ssp-model-management-feature.md
@@ -56,14 +56,13 @@ Add the following configuration to `config/Shared/config_default.php`:
 ```php
 <?php
 
-use Spryker\Service\FlysystemLocalFileSystem\Plugin\Flysystem\LocalFilesystemBuilderPlugin;
 use Spryker\Shared\FileSystem\FileSystemConstants;
-use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;
+use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\IamAws3v3FilesystemBuilderPlugin;
 use SprykerFeature\Shared\SelfServicePortal\SelfServicePortalConstants;
 
 $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
      'ssp-model-image' => [
-        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
+        'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
         'key' => getenv('SPRYKER_S3_SSP_MODELS_KEY') ?: '',
         'secret' => getenv('SPRYKER_S3_SSP_MODELS_SECRET') ?: '',
         'bucket' => getenv('SPRYKER_S3_SSP_MODELS_BUCKET') ?: '',

--- a/_includes/pbc/all/install-features/latest/install-the-ssp-model-management-feature.md
+++ b/_includes/pbc/all/install-features/latest/install-the-ssp-model-management-feature.md
@@ -63,13 +63,9 @@ use SprykerFeature\Shared\SelfServicePortal\SelfServicePortalConstants;
 $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
      'ssp-model-image' => [
         'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_SSP_MODELS_KEY') ?: '',
-        'secret' => getenv('SPRYKER_S3_SSP_MODELS_SECRET') ?: '',
         'bucket' => getenv('SPRYKER_S3_SSP_MODELS_BUCKET') ?: '',
         'region' => getenv('AWS_REGION') ?: '',
-        'version' => 'latest',
-        'root' => '/ssp-model-image',
-        'path' => '',
+        'path' => '/ssp-model-image',
     ],
 ];
 
@@ -90,6 +86,25 @@ In cloud environments, set the following environment variables:
 - `AWS_REGION` - AWS region
 
 {% endinfo_block %}
+
+Alternatively, to authenticate with explicit access keys instead of an IAM role, use `Aws3v3FilesystemBuilderPlugin`:
+
+```php
+use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;
+
+$config[FileSystemConstants::FILESYSTEM_SERVICE] = [
+    'ssp-model-image' => [
+        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
+        'key' => getenv('SPRYKER_S3_SSP_MODELS_KEY') ?: '',
+        'secret' => getenv('SPRYKER_S3_SSP_MODELS_SECRET') ?: '',
+        'bucket' => getenv('SPRYKER_S3_SSP_MODELS_BUCKET') ?: '',
+        'region' => getenv('AWS_REGION') ?: '',
+        'version' => 'latest',
+        'root' => '/ssp-model-image',
+        'path' => '',
+    ],
+];
+```
 
 ## Configure synchronization queues
 

--- a/_includes/pbc/all/install-features/latest/install-the-ssp-model-management-feature.md
+++ b/_includes/pbc/all/install-features/latest/install-the-ssp-model-management-feature.md
@@ -53,6 +53,8 @@ Add the following configuration to `config/Shared/config_default.php`:
 
 **config/Shared/config_default.php**
 
+To enable an IAM role configuration, use `IamAws3v3FilesystemBuilderPlugin`:
+
 ```php
 <?php
 
@@ -87,7 +89,7 @@ In cloud environments, set the following environment variables:
 
 {% endinfo_block %}
 
-Alternatively, to authenticate with explicit access keys instead of an IAM role, use `Aws3v3FilesystemBuilderPlugin`:
+Alternatively, to authenticate with explicit access keys, use `Aws3v3FilesystemBuilderPlugin`:
 
 ```php
 use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;

--- a/_includes/pbc/all/install-features/latest/install-the-ssp-model-management-feature.md
+++ b/_includes/pbc/all/install-features/latest/install-the-ssp-model-management-feature.md
@@ -82,31 +82,16 @@ $config[SelfServicePortalConstants::SSP_MODEL_IMAGE_STORAGE_NAME] = 'ssp-model-i
 
 In cloud environments, set the following environment variables:
 
-- `SPRYKER_S3_SSP_MODELS_KEY` - AWS S3 access key for SSP model file storage
-- `SPRYKER_S3_SSP_MODELS_SECRET` - AWS S3 secret key for SSP model file storage
 - `SPRYKER_S3_SSP_MODELS_BUCKET` - AWS S3 bucket name for SSP model file storage
 - `AWS_REGION` - AWS region
 
 {% endinfo_block %}
 
-Alternatively, to authenticate with explicit access keys, use `Aws3v3FilesystemBuilderPlugin`:
+{% info_block warningBox "IAM authentication required" %}
 
-```php
-use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;
+These buckets authenticate through the IAM role attached to the workload. Access keys (`key` and `secret`) are not supported. If your project was set up from older documentation using access keys, migrate to this configuration. For more details, see [AWS S3 filesystem builder plugins](/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.html#aws-s3-filesystem-builder-plugins).
 
-$config[FileSystemConstants::FILESYSTEM_SERVICE] = [
-    'ssp-model-image' => [
-        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_SSP_MODELS_KEY') ?: '',
-        'secret' => getenv('SPRYKER_S3_SSP_MODELS_SECRET') ?: '',
-        'bucket' => getenv('SPRYKER_S3_SSP_MODELS_BUCKET') ?: '',
-        'region' => getenv('AWS_REGION') ?: '',
-        'version' => 'latest',
-        'root' => '/ssp-model-image',
-        'path' => '',
-    ],
-];
-```
+{% endinfo_block %}
 
 ## Configure synchronization queues
 

--- a/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.md
+++ b/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.md
@@ -434,9 +434,15 @@ The `FlysystemAws3v3FileSystem` module provides two builder plugins for Amazon S
 | Required adapter config | `key`, `secret`, `bucket`, `region`, `path` | `bucket`, `region` |
 | `key` / `secret` | Used | Ignored |
 | `endpoint` | Always passed to the S3 client | Passed only when non-empty |
-| Recommended for | Environments where explicit access keys are provisioned | Spryker-managed (PaaS) environments with an IAM role attached to the workload |
+| Recommended for | Buckets provisioned with explicit access keys, such as the legacy `csv-import` bucket | Spryker-managed asset, import/export, and self-service buckets, where it is required |
 
 Both plugins can be registered side by side. The `sprykerAdapterClass` value of each filesystem entry decides which plugin builds that filesystem, so different filesystems can use different credential strategies at the same time. Switching an existing filesystem from one plugin to the other is not a breaking change, and nothing is migrated automatically.
+
+{% info_block warningBox "IAM-only buckets" %}
+
+On Spryker-managed environments, the asset, import/export, and self-service buckets authenticate exclusively through the IAM role attached to the workload. Access keys are not supported for these buckets, so they must use `IamAws3v3FilesystemBuilderPlugin`. Use `Aws3v3FilesystemBuilderPlugin` only for buckets that are provisioned with explicit access keys, such as the legacy `csv-import` bucket.
+
+{% endinfo_block %}
 
 ### IamAws3v3FilesystemBuilderPlugin
 
@@ -502,7 +508,7 @@ For local development, set the `endpoint` option to point at an S3-compatible se
 
 ### Aws3v3FilesystemBuilderPlugin
 
-Use `Aws3v3FilesystemBuilderPlugin` when the environment provisions explicit access keys instead of an IAM role. The plugin reads `key` and `secret` from the adapter config and passes them to the S3 client as static credentials.
+Use `Aws3v3FilesystemBuilderPlugin` for buckets provisioned with explicit access keys, such as the legacy `csv-import` bucket. The plugin reads `key` and `secret` from the adapter config and passes them to the S3 client as static credentials. Do not use it for the Spryker-managed asset, import/export, and self-service buckets, which require `IamAws3v3FilesystemBuilderPlugin`.
 
 #### Configuration example
 

--- a/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.md
+++ b/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.md
@@ -1,7 +1,7 @@
 ---
 title: Flysystem
 description: The Flysystem module integrates Spryker with the thephpleague flysystem vendor package
-last_updated: Jun 16, 2021
+last_updated: Jul 27, 2026
 template: howto-guide-template
 originalLink: https://documentation.spryker.com/2021080/docs/flysystem
 originalArticleId: b68c1798-4db1-4a2b-87bf-b54d4052a741
@@ -423,6 +423,82 @@ abstract class AbstractFilesystemBuilder implements FilesystemBuilderInterface
 
 }
 ```
+
+## AWS S3 filesystem builder plugins
+
+The `FlysystemAws3v3FileSystem` module provides two builder plugins for Amazon S3. Both return a `\League\Flysystem\Filesystem` backed by the AWS S3 v3 adapter; they differ only in how AWS credentials are resolved.
+
+| | `Aws3v3FilesystemBuilderPlugin` | `IamAws3v3FilesystemBuilderPlugin` |
+| --- | --- | --- |
+| Credentials | Explicit `key` and `secret` from the adapter config | Resolved automatically by the AWS SDK default credential provider chain |
+| Required adapter config | `key`, `secret`, `bucket`, `region`, `path` | `bucket`, `region` |
+| `key` / `secret` | Used | Ignored |
+| `endpoint` | Always passed to the S3 client | Passed only when non-empty |
+| Recommended for | Environments where explicit access keys are provisioned | Spryker-managed (PaaS) environments with an IAM role attached to the workload |
+
+Both plugins can be registered side by side. The `sprykerAdapterClass` value of each filesystem entry decides which plugin builds that filesystem, so different filesystems can use different credential strategies at the same time. Switching an existing filesystem from one plugin to the other is not a breaking change, and nothing is migrated automatically.
+
+### IamAws3v3FilesystemBuilderPlugin
+
+Use `IamAws3v3FilesystemBuilderPlugin` when the runtime—an ECS task or EC2 instance—carries an IAM role that grants access to the target bucket. The plugin does not pass a `credentials` entry to the S3 client, so the AWS SDK falls back to its default credential provider chain: environment variables (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`), the shared credentials and config files, ECS container credentials, and finally EC2 instance metadata (IMDS).
+
+This is the recommended option for Spryker-managed (PaaS) environments, where storing long-lived `key` and `secret` pairs in the container is undesirable. It is used, for example, for the public-media buckets that store Back Office, Storefront, and Merchant Portal media, and for the Product Experience Management import and export filesystems.
+
+#### Adapter configuration reference
+
+| PROPERTY | REQUIRED | DESCRIPTION |
+| --- | --- | --- |
+| `bucket` | Yes | Target S3 bucket. A missing value throws `NoBucketException`. |
+| `region` | Yes | AWS region of the bucket. |
+| `path` | No | Path prefix inside the bucket. Defaults to an empty string. |
+| `endpoint` | No | Custom endpoint for S3-compatible storage such as MinIO or LocalStack. Applied only when non-empty. |
+| `isStreamReads` | No | Whether reads are streamed. Defaults to `false`. |
+| `key`, `secret` | Ignored | Not read by this plugin. Credentials come from the IAM role or the AWS SDK credential chain. |
+
+{% info_block infoBox "Credentials in configuration" %}
+
+Because `IamAws3v3FilesystemBuilderPlugin` ignores `key` and `secret`, you do not need to set them for filesystems that use this plugin. If they are present, they have no effect.
+
+{% endinfo_block %}
+
+#### Configuration example
+
+**config/Shared/config_default.php**
+
+```php
+use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\IamAws3v3FilesystemBuilderPlugin;
+use Spryker\Shared\FileSystem\FileSystemConstants;
+
+$config[FileSystemConstants::FILESYSTEM_SERVICE] = [
+    // ... existing entries ...
+    'backoffice-media' => [
+        'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
+        'bucket' => getenv('SPRYKER_S3_PUBLIC_ASSETS_BUCKET') ?: '',
+        'path' => '/backoffice-media',
+        'region' => getenv('AWS_REGION'),
+    ],
+];
+```
+
+#### Registration
+
+Register the plugin in `\Pyz\Service\Flysystem\FlysystemDependencyProvider::getFilesystemBuilderPluginCollection()` next to the other builder plugins:
+
+```php
+protected function getFilesystemBuilderPluginCollection(): array
+{
+    return [
+        new FtpFilesystemBuilderPlugin(),
+        new LocalFilesystemBuilderPlugin(),
+        new Aws3v3FilesystemBuilderPlugin(),
+        new IamAws3v3FilesystemBuilderPlugin(),
+    ];
+}
+```
+
+#### Local development
+
+For local development, set the `endpoint` option to point at an S3-compatible service such as MinIO or LocalStack. Alternatively, use `LocalFilesystemBuilderPlugin` when no bucket is configured.
 
 ## Flysystem plugins
 

--- a/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.md
+++ b/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.md
@@ -474,8 +474,8 @@ $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
     'backoffice-media' => [
         'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
         'bucket' => getenv('SPRYKER_S3_PUBLIC_ASSETS_BUCKET') ?: '',
+        'region' => getenv('AWS_REGION') ?: '',
         'path' => '/backoffice-media',
-        'region' => getenv('AWS_REGION'),
     ],
 ];
 ```
@@ -499,6 +499,31 @@ protected function getFilesystemBuilderPluginCollection(): array
 #### Local development
 
 For local development, set the `endpoint` option to point at an S3-compatible service such as MinIO or LocalStack. Alternatively, use `LocalFilesystemBuilderPlugin` when no bucket is configured.
+
+### Aws3v3FilesystemBuilderPlugin
+
+Use `Aws3v3FilesystemBuilderPlugin` when the environment provisions explicit access keys instead of an IAM role. The plugin reads `key` and `secret` from the adapter config and passes them to the S3 client as static credentials.
+
+#### Configuration example
+
+**config/Shared/config_default.php**
+
+```php
+use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;
+use Spryker\Shared\FileSystem\FileSystemConstants;
+
+$config[FileSystemConstants::FILESYSTEM_SERVICE] = [
+    // ... existing entries ...
+    'backoffice-media' => [
+        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
+        'key' => getenv('SPRYKER_S3_PUBLIC_ASSETS_KEY') ?: '',
+        'secret' => getenv('SPRYKER_S3_PUBLIC_ASSETS_SECRET') ?: '',
+        'bucket' => getenv('SPRYKER_S3_PUBLIC_ASSETS_BUCKET') ?: '',
+        'region' => getenv('AWS_REGION') ?: '',
+        'path' => '/backoffice-media',
+    ],
+];
+```
 
 ## Flysystem plugins
 

--- a/docs/dg/dev/integrate-and-configure/integrate-basic-shop-theme.md
+++ b/docs/dg/dev/integrate-and-configure/integrate-basic-shop-theme.md
@@ -131,45 +131,66 @@ Add the three media filesystem entries inside the existing `$config[FileSystemCo
 
 ```php
 $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
-    // ... existing entries ...
     'backoffice-media' => [
         'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_PUBLIC_ASSETS_KEY') ?: '',
         'bucket' => getenv('SPRYKER_S3_PUBLIC_ASSETS_BUCKET') ?: '',
-        'secret' => getenv('SPRYKER_S3_PUBLIC_ASSETS_SECRET') ?: '',
-        'root' => '/backoffice-media',
-        'path' => '/',
-        'version' => 'latest',
-        'region' => getenv('AWS_REGION'),
+        'region' => getenv('AWS_REGION') ?: '',
+        'path' => '/backoffice-media',
     ],
     'storefront-media' => [
         'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_PUBLIC_ASSETS_KEY') ?: '',
         'bucket' => getenv('SPRYKER_S3_PUBLIC_ASSETS_BUCKET') ?: '',
-        'secret' => getenv('SPRYKER_S3_PUBLIC_ASSETS_SECRET') ?: '',
-        'root' => '/storefront-media',
-        'path' => '',
-        'version' => 'latest',
-        'region' => getenv('AWS_REGION'),
+        'region' => getenv('AWS_REGION') ?: '',
+        'path' => '/storefront-media',
     ],
     'merchant-portal-media' => [
         'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_PUBLIC_ASSETS_KEY') ?: '',
         'bucket' => getenv('SPRYKER_S3_PUBLIC_ASSETS_BUCKET') ?: '',
-        'secret' => getenv('SPRYKER_S3_PUBLIC_ASSETS_SECRET') ?: '',
-        'root' => '/merchant-portal-media',
-        'path' => '',
-        'version' => 'latest',
-        'region' => getenv('AWS_REGION'),
+        'region' => getenv('AWS_REGION') ?: '',
+        'path' => '/merchant-portal-media',
     ],
 ];
 ```
 
 {% info_block infoBox "Credentials" %}
 
-These filesystems use `IamAws3v3FilesystemBuilderPlugin`, which resolves AWS credentials through the IAM role attached to the runtime instead of explicit access keys. The `key` and `secret` entries are ignored by this plugin. For details on when to use this plugin and its configuration options, see [AWS S3 filesystem builder plugins](/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.html#aws-s3-filesystem-builder-plugins).
+These filesystems use `IamAws3v3FilesystemBuilderPlugin`, which resolves AWS credentials through the IAM role attached to the runtime, so no `key` or `secret` is required. For details on when to use this plugin and its configuration options, see [AWS S3 filesystem builder plugins](/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.html#aws-s3-filesystem-builder-plugins).
 
 {% endinfo_block %}
+
+Alternatively, to authenticate with explicit access keys instead of an IAM role, use `Aws3v3FilesystemBuilderPlugin`:
+
+```php
+$config[FileSystemConstants::FILESYSTEM_SERVICE] = [
+    'backoffice-media' => [
+        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
+        'key' => getenv('SPRYKER_S3_PUBLIC_ASSETS_KEY') ?: '',
+        'secret' => getenv('SPRYKER_S3_PUBLIC_ASSETS_SECRET') ?: '',
+        'bucket' => getenv('SPRYKER_S3_PUBLIC_ASSETS_BUCKET') ?: '',
+        'region' => getenv('AWS_REGION') ?: '',
+        'root' => '/backoffice-media',
+        'path' => '/',
+    ],
+    'storefront-media' => [
+        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
+        'key' => getenv('SPRYKER_S3_PUBLIC_ASSETS_KEY') ?: '',
+        'secret' => getenv('SPRYKER_S3_PUBLIC_ASSETS_SECRET') ?: '',
+        'bucket' => getenv('SPRYKER_S3_PUBLIC_ASSETS_BUCKET') ?: '',
+        'region' => getenv('AWS_REGION') ?: '',
+        'root' => '/storefront-media',
+        'path' => '',
+    ],
+    'merchant-portal-media' => [
+        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
+        'key' => getenv('SPRYKER_S3_PUBLIC_ASSETS_KEY') ?: '',
+        'secret' => getenv('SPRYKER_S3_PUBLIC_ASSETS_SECRET') ?: '',
+        'bucket' => getenv('SPRYKER_S3_PUBLIC_ASSETS_BUCKET') ?: '',
+        'region' => getenv('AWS_REGION') ?: '',
+        'root' => '/merchant-portal-media',
+        'path' => '',
+    ],
+];
+```
 
 #### 4.2) Add local filesystem fallback for development
 

--- a/docs/dg/dev/integrate-and-configure/integrate-basic-shop-theme.md
+++ b/docs/dg/dev/integrate-and-configure/integrate-basic-shop-theme.md
@@ -133,7 +133,7 @@ Add the three media filesystem entries inside the existing `$config[FileSystemCo
 $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
     // ... existing entries ...
     'backoffice-media' => [
-        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
+        'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
         'key' => getenv('SPRYKER_S3_PUBLIC_ASSETS_KEY') ?: '',
         'bucket' => getenv('SPRYKER_S3_PUBLIC_ASSETS_BUCKET') ?: '',
         'secret' => getenv('SPRYKER_S3_PUBLIC_ASSETS_SECRET') ?: '',
@@ -143,7 +143,7 @@ $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
         'region' => getenv('AWS_REGION'),
     ],
     'storefront-media' => [
-        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
+        'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
         'key' => getenv('SPRYKER_S3_PUBLIC_ASSETS_KEY') ?: '',
         'bucket' => getenv('SPRYKER_S3_PUBLIC_ASSETS_BUCKET') ?: '',
         'secret' => getenv('SPRYKER_S3_PUBLIC_ASSETS_SECRET') ?: '',
@@ -153,7 +153,7 @@ $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
         'region' => getenv('AWS_REGION'),
     ],
     'merchant-portal-media' => [
-        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
+        'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
         'key' => getenv('SPRYKER_S3_PUBLIC_ASSETS_KEY') ?: '',
         'bucket' => getenv('SPRYKER_S3_PUBLIC_ASSETS_BUCKET') ?: '',
         'secret' => getenv('SPRYKER_S3_PUBLIC_ASSETS_SECRET') ?: '',

--- a/docs/dg/dev/integrate-and-configure/integrate-basic-shop-theme.md
+++ b/docs/dg/dev/integrate-and-configure/integrate-basic-shop-theme.md
@@ -152,45 +152,11 @@ $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
 ];
 ```
 
-{% info_block infoBox "Credentials" %}
+{% info_block warningBox "IAM authentication required" %}
 
-These filesystems use `IamAws3v3FilesystemBuilderPlugin`, which resolves AWS credentials through the IAM role attached to the runtime, so no `key` or `secret` is required. For details on when to use this plugin and its configuration options, see [AWS S3 filesystem builder plugins](/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.html#aws-s3-filesystem-builder-plugins).
+These filesystems authenticate through the IAM role attached to the workload, which resolves AWS credentials automatically. Access keys (`key` and `secret`) are not supported. If your project was set up from older documentation using access keys, migrate to this configuration. For more details, see [AWS S3 filesystem builder plugins](/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.html#aws-s3-filesystem-builder-plugins).
 
 {% endinfo_block %}
-
-Alternatively, to authenticate with explicit access keys, use `Aws3v3FilesystemBuilderPlugin`:
-
-```php
-$config[FileSystemConstants::FILESYSTEM_SERVICE] = [
-    'backoffice-media' => [
-        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_PUBLIC_ASSETS_KEY') ?: '',
-        'secret' => getenv('SPRYKER_S3_PUBLIC_ASSETS_SECRET') ?: '',
-        'bucket' => getenv('SPRYKER_S3_PUBLIC_ASSETS_BUCKET') ?: '',
-        'region' => getenv('AWS_REGION') ?: '',
-        'root' => '/backoffice-media',
-        'path' => '/',
-    ],
-    'storefront-media' => [
-        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_PUBLIC_ASSETS_KEY') ?: '',
-        'secret' => getenv('SPRYKER_S3_PUBLIC_ASSETS_SECRET') ?: '',
-        'bucket' => getenv('SPRYKER_S3_PUBLIC_ASSETS_BUCKET') ?: '',
-        'region' => getenv('AWS_REGION') ?: '',
-        'root' => '/storefront-media',
-        'path' => '',
-    ],
-    'merchant-portal-media' => [
-        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_PUBLIC_ASSETS_KEY') ?: '',
-        'secret' => getenv('SPRYKER_S3_PUBLIC_ASSETS_SECRET') ?: '',
-        'bucket' => getenv('SPRYKER_S3_PUBLIC_ASSETS_BUCKET') ?: '',
-        'region' => getenv('AWS_REGION') ?: '',
-        'root' => '/merchant-portal-media',
-        'path' => '',
-    ],
-];
-```
 
 #### 4.2) Add local filesystem fallback for development
 

--- a/docs/dg/dev/integrate-and-configure/integrate-basic-shop-theme.md
+++ b/docs/dg/dev/integrate-and-configure/integrate-basic-shop-theme.md
@@ -2,7 +2,7 @@
 title: Install the Basic Shop Theme feature
 description: Learn how to integrate the Basic Shop Theme feature to configure logos, colors, and custom CSS from the Back Office without code changes.
 template: howto-guide-template
-last_updated: Apr 1, 2026
+last_updated: Jul 27, 2026
 related:
   - title: Basic Shop Theme feature overview
     link: /docs/pbc/all/back-office/latest/base-shop/basic-shop-theme-feature-overview.html
@@ -164,6 +164,12 @@ $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
     ],
 ];
 ```
+
+{% info_block infoBox "Credentials" %}
+
+These filesystems use `IamAws3v3FilesystemBuilderPlugin`, which resolves AWS credentials through the IAM role attached to the runtime instead of explicit access keys. The `key` and `secret` entries are ignored by this plugin. For details on when to use this plugin and its configuration options, see [AWS S3 filesystem builder plugins](/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.html#aws-s3-filesystem-builder-plugins).
+
+{% endinfo_block %}
 
 #### 4.2) Add local filesystem fallback for development
 

--- a/docs/dg/dev/integrate-and-configure/integrate-basic-shop-theme.md
+++ b/docs/dg/dev/integrate-and-configure/integrate-basic-shop-theme.md
@@ -127,7 +127,7 @@ Add the three media filesystem services to `config/Shared/config_default.php`. I
 
 **config/Shared/config_default.php**
 
-Add the three media filesystem entries inside the existing `$config[FileSystemConstants::FILESYSTEM_SERVICE]` array:
+Add the three media filesystem entries inside the existing `$config[FileSystemConstants::FILESYSTEM_SERVICE]` array. To enable an IAM role configuration, use `IamAws3v3FilesystemBuilderPlugin`:
 
 ```php
 $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
@@ -158,7 +158,7 @@ These filesystems use `IamAws3v3FilesystemBuilderPlugin`, which resolves AWS cre
 
 {% endinfo_block %}
 
-Alternatively, to authenticate with explicit access keys instead of an IAM role, use `Aws3v3FilesystemBuilderPlugin`:
+Alternatively, to authenticate with explicit access keys, use `Aws3v3FilesystemBuilderPlugin`:
 
 ```php
 $config[FileSystemConstants::FILESYSTEM_SERVICE] = [

--- a/docs/pbc/all/product-experience-management/latest/install-the-product-experience-management-feature.md
+++ b/docs/pbc/all/product-experience-management/latest/install-the-product-experience-management-feature.md
@@ -53,32 +53,30 @@ Configure the filesystem storage for import and export files. The feature requir
 **config/Shared/config_default.php**
 
 ```php
-use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;
+use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\IamAws3v3FilesystemBuilderPlugin;
 use Spryker\Shared\FileSystem\FileSystemConstants;
 
 $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
     // ... existing entries ...
     'product-experience-management-imports' => [
-        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
+        'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
         'key' => getenv('SPRYKER_S3_PEM_IMPORT_KEY') ?: '',
         'bucket' => getenv('SPRYKER_S3_PEM_IMPORT_BUCKET') ?: '',
         'secret' => getenv('SPRYKER_S3_PEM_IMPORT_SECRET') ?: '',
         'root' => '/',
-        'path' => 'pem-imports/',
-        'region' => getenv('SPRYKER_S3_PEM_IMPORT_REGION') ?: '',
-        'version' => getenv('SPRYKER_S3_PEM_IMPORT_VERSION') ?: 'latest',
-        'endpoint' => getenv('SPRYKER_S3_PEM_IMPORT_ENDPOINT') ?: null,
+        'path' => '/',
+        'version' => 'latest',
+        'region' => $awsRegion,
     ],
     'product-experience-management-exports' => [
-        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
+        'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
         'key' => getenv('SPRYKER_S3_PEM_EXPORT_KEY') ?: '',
         'bucket' => getenv('SPRYKER_S3_PEM_EXPORT_BUCKET') ?: '',
         'secret' => getenv('SPRYKER_S3_PEM_EXPORT_SECRET') ?: '',
         'root' => '/',
-        'path' => 'pem-exports/',
-        'region' => getenv('SPRYKER_S3_PEM_EXPORT_REGION') ?: '',
-        'version' => getenv('SPRYKER_S3_PEM_EXPORT_VERSION') ?: 'latest',
-        'endpoint' => getenv('SPRYKER_S3_PEM_EXPORT_ENDPOINT') ?: null,
+        'path' => '/',
+        'version' => 'latest',
+        'region' => $awsRegion,
     ],
 ];
 ```

--- a/docs/pbc/all/product-experience-management/latest/install-the-product-experience-management-feature.md
+++ b/docs/pbc/all/product-experience-management/latest/install-the-product-experience-management-feature.md
@@ -1,7 +1,7 @@
 ---
 title: Install the Product Experience Management feature
 description: Learn how to install the Product Experience Management feature into your Spryker project.
-last_updated: Apr 08 2026
+last_updated: Jul 27 2026
 template: feature-integration-guide-template
 ---
 

--- a/docs/pbc/all/product-experience-management/latest/install-the-product-experience-management-feature.md
+++ b/docs/pbc/all/product-experience-management/latest/install-the-product-experience-management-feature.md
@@ -75,40 +75,11 @@ $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
 ];
 ```
 
-{% info_block infoBox "Credentials" %}
+{% info_block warningBox "IAM authentication required" %}
 
-These filesystems use `IamAws3v3FilesystemBuilderPlugin`, which resolves AWS credentials through the IAM role attached to the runtime, so no `key` or `secret` is required. For details on when to use this plugin and its configuration options, see [AWS S3 filesystem builder plugins](/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.html#aws-s3-filesystem-builder-plugins).
+These filesystems authenticate through the IAM role attached to the workload, which resolves AWS credentials automatically. Access keys (`key` and `secret`) are not supported. If your project was set up from older documentation using access keys, migrate to this configuration. For more details, see [AWS S3 filesystem builder plugins](/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.html#aws-s3-filesystem-builder-plugins).
 
 {% endinfo_block %}
-
-Alternatively, to authenticate with explicit access keys, use `Aws3v3FilesystemBuilderPlugin`:
-
-```php
-use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;
-use Spryker\Shared\FileSystem\FileSystemConstants;
-
-$config[FileSystemConstants::FILESYSTEM_SERVICE] = [
-    // ... existing entries ...
-    'product-experience-management-imports' => [
-        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_PEM_IMPORT_KEY') ?: '',
-        'secret' => getenv('SPRYKER_S3_PEM_IMPORT_SECRET') ?: '',
-        'bucket' => getenv('SPRYKER_S3_PEM_IMPORT_BUCKET') ?: '',
-        'region' => getenv('AWS_REGION') ?: '',
-        'root' => '/',
-        'path' => 'pem-imports/',
-    ],
-    'product-experience-management-exports' => [
-        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_PEM_EXPORT_KEY') ?: '',
-        'secret' => getenv('SPRYKER_S3_PEM_EXPORT_SECRET') ?: '',
-        'bucket' => getenv('SPRYKER_S3_PEM_EXPORT_BUCKET') ?: '',
-        'region' => getenv('AWS_REGION') ?: '',
-        'root' => '/',
-        'path' => 'pem-exports/',
-    ],
-];
-```
 
 #### Development (local filesystem)
 

--- a/docs/pbc/all/product-experience-management/latest/install-the-product-experience-management-feature.md
+++ b/docs/pbc/all/product-experience-management/latest/install-the-product-experience-management-feature.md
@@ -52,6 +52,8 @@ Configure the filesystem storage for import and export files. The feature requir
 
 **config/Shared/config_default.php**
 
+To enable an IAM role configuration, use `IamAws3v3FilesystemBuilderPlugin`:
+
 ```php
 use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\IamAws3v3FilesystemBuilderPlugin;
 use Spryker\Shared\FileSystem\FileSystemConstants;
@@ -79,7 +81,7 @@ These filesystems use `IamAws3v3FilesystemBuilderPlugin`, which resolves AWS cre
 
 {% endinfo_block %}
 
-Alternatively, to authenticate with explicit access keys instead of an IAM role, use `Aws3v3FilesystemBuilderPlugin`:
+Alternatively, to authenticate with explicit access keys, use `Aws3v3FilesystemBuilderPlugin`:
 
 ```php
 use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;

--- a/docs/pbc/all/product-experience-management/latest/install-the-product-experience-management-feature.md
+++ b/docs/pbc/all/product-experience-management/latest/install-the-product-experience-management-feature.md
@@ -81,6 +81,12 @@ $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
 ];
 ```
 
+{% info_block infoBox "Credentials" %}
+
+These filesystems use `IamAws3v3FilesystemBuilderPlugin`, which resolves AWS credentials through the IAM role attached to the runtime instead of explicit access keys. The `key` and `secret` entries are ignored by this plugin. For details on when to use this plugin and its configuration options, see [AWS S3 filesystem builder plugins](/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.html#aws-s3-filesystem-builder-plugins).
+
+{% endinfo_block %}
+
 #### Development (local filesystem)
 
 **config/Shared/config_default-docker.dev.php**

--- a/docs/pbc/all/product-experience-management/latest/install-the-product-experience-management-feature.md
+++ b/docs/pbc/all/product-experience-management/latest/install-the-product-experience-management-feature.md
@@ -60,32 +60,53 @@ $config[FileSystemConstants::FILESYSTEM_SERVICE] = [
     // ... existing entries ...
     'product-experience-management-imports' => [
         'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_PEM_IMPORT_KEY') ?: '',
         'bucket' => getenv('SPRYKER_S3_PEM_IMPORT_BUCKET') ?: '',
-        'secret' => getenv('SPRYKER_S3_PEM_IMPORT_SECRET') ?: '',
-        'root' => '/',
-        'path' => '/',
-        'version' => 'latest',
-        'region' => $awsRegion,
+        'region' => getenv('AWS_REGION') ?: '',
+        'path' => 'pem-imports/',
     ],
     'product-experience-management-exports' => [
         'sprykerAdapterClass' => IamAws3v3FilesystemBuilderPlugin::class,
-        'key' => getenv('SPRYKER_S3_PEM_EXPORT_KEY') ?: '',
         'bucket' => getenv('SPRYKER_S3_PEM_EXPORT_BUCKET') ?: '',
-        'secret' => getenv('SPRYKER_S3_PEM_EXPORT_SECRET') ?: '',
-        'root' => '/',
-        'path' => '/',
-        'version' => 'latest',
-        'region' => $awsRegion,
+        'region' => getenv('AWS_REGION') ?: '',
+        'path' => 'pem-exports/',
     ],
 ];
 ```
 
 {% info_block infoBox "Credentials" %}
 
-These filesystems use `IamAws3v3FilesystemBuilderPlugin`, which resolves AWS credentials through the IAM role attached to the runtime instead of explicit access keys. The `key` and `secret` entries are ignored by this plugin. For details on when to use this plugin and its configuration options, see [AWS S3 filesystem builder plugins](/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.html#aws-s3-filesystem-builder-plugins).
+These filesystems use `IamAws3v3FilesystemBuilderPlugin`, which resolves AWS credentials through the IAM role attached to the runtime, so no `key` or `secret` is required. For details on when to use this plugin and its configuration options, see [AWS S3 filesystem builder plugins](/docs/dg/dev/backend-development/data-manipulation/data-ingestion/structural-preparations/flysystem.html#aws-s3-filesystem-builder-plugins).
 
 {% endinfo_block %}
+
+Alternatively, to authenticate with explicit access keys instead of an IAM role, use `Aws3v3FilesystemBuilderPlugin`:
+
+```php
+use Spryker\Service\FlysystemAws3v3FileSystem\Plugin\Flysystem\Aws3v3FilesystemBuilderPlugin;
+use Spryker\Shared\FileSystem\FileSystemConstants;
+
+$config[FileSystemConstants::FILESYSTEM_SERVICE] = [
+    // ... existing entries ...
+    'product-experience-management-imports' => [
+        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
+        'key' => getenv('SPRYKER_S3_PEM_IMPORT_KEY') ?: '',
+        'secret' => getenv('SPRYKER_S3_PEM_IMPORT_SECRET') ?: '',
+        'bucket' => getenv('SPRYKER_S3_PEM_IMPORT_BUCKET') ?: '',
+        'region' => getenv('AWS_REGION') ?: '',
+        'root' => '/',
+        'path' => 'pem-imports/',
+    ],
+    'product-experience-management-exports' => [
+        'sprykerAdapterClass' => Aws3v3FilesystemBuilderPlugin::class,
+        'key' => getenv('SPRYKER_S3_PEM_EXPORT_KEY') ?: '',
+        'secret' => getenv('SPRYKER_S3_PEM_EXPORT_SECRET') ?: '',
+        'bucket' => getenv('SPRYKER_S3_PEM_EXPORT_BUCKET') ?: '',
+        'region' => getenv('AWS_REGION') ?: '',
+        'root' => '/',
+        'path' => 'pem-exports/',
+    ],
+];
+```
 
 #### Development (local filesystem)
 


### PR DESCRIPTION
## PR Description

Switch the S3 media and import/export filesystems to IamAws3v3FilesystemBuilderPlugin so credentials resolve through the IAM role attached to the runtime, instead of requiring explicit key/secret that new (Spryker-managed) environments don't provision out of the box.

Changes

- Use IamAws3v3FilesystemBuilderPlugin for public-media filesystems (Back Office, Storefront, Merchant Portal) and PEM/SSP import/export filesystems.
- Document the new plugin in flysystem.md: comparison table, credential resolution, adapter config reference, and configuration/registration examples.
- Trim inert keys (key/secret/root/version) from IAM examples and show an Aws3v3FilesystemBuilderPlugin alternative for environments that use explicit access keys.
- Fix undefined $awsRegion (→ getenv('AWS_REGION') ?: '') and correct SSP inquiry env-var names (SSP_CLAIM → SSP_INQUIRIES).

## Tickets
https://spryker.atlassian.net/browse/SUPESC-1131


