### PR TITLE
Document the project-ci-generator AI Dev SDK skill

### DIFF
--- a/docs/dg/dev/ai/ai-dev/ai-dev-claude-code-plugin.md
+++ b/docs/dg/dev/ai/ai-dev/ai-dev-claude-code-plugin.md
@@ -1,9 +1,9 @@
 ---
 title: Claude Code Plugin
 description: Install and use the Spryker AI Dev SDK plugin for Claude Code to get Spryker-aware skills, code review, and project setup directly in your AI coding assistant.
-last_updated: Jul 22, 2026
+last_updated: Jul 28, 2026
 label: early-access
-keywords: ai, claude, claude code, plugin, marketplace, skills, spryker, ai-dev, code review
+keywords: ai, claude, claude code, plugin, marketplace, skills, spryker, ai-dev, code review, ci
 template: howto-guide-template
 ---
 
@@ -111,6 +111,7 @@ The plugin bundles the following Spryker-aware skills. Invoke them in Claude Cod
 | Spryker Docs Research | `/spryker-ai-dev-sdk:spryker-docs-research` | Looks up grounded answers in the official Spryker documentation |
 | Spryker Runtime | `/spryker-ai-dev-sdk:spryker-runtime` | Drives the running Spryker application — storefront, back office, console, HTTP |
 | AI Runtime Debugging | `/spryker-ai-dev-sdk:ai-runtime-debugging` | Adds tagged debug logs (and optional XDebug) for inspecting Spryker runtime state |
+| Project CI Generator | `/spryker-ai-dev-sdk:project-ci-generator` | Rebuilds an inherited product-style CI setup into a single, lean project CI pipeline, keeping only the jobs and support files the project needs |
 
 ### Subagents
 

--- a/docs/dg/dev/ai/ai-dev/ai-dev-skills-and-agents.md
+++ b/docs/dg/dev/ai/ai-dev/ai-dev-skills-and-agents.md
@@ -1,7 +1,7 @@
 ---
 title: AI Dev SDK Skills and Agents
 description: Reference of the skills and agents shipped with the AI Dev SDK
-last_updated: Jul 22, 2026
+last_updated: Jul 28, 2026
 label: early-access
 keywords: ai, ai-dev, claude, claude code, windsurf, copilot, skills, agents, subagents, spryker
 template: concept-topic-template
@@ -61,6 +61,7 @@ Skills are delivered through `ai-dev:setup` (all supported AI tools) or the Clau
 | `spryker-docs-research` | Look up the right answer in official Spryker documentation | Grounds AI work in documented behavior rather than the model's memory; falls back gracefully when MCP tools are unavailable |
 | `spryker-runtime` | Drive the running Spryker application — Yves, Back Office, Merchant Portal, console, HTTP | Real authenticated sessions; read-only DB / Redis / queue inspection; reusable building block for higher-level skills and agents |
 | `ai-runtime-debugging` | Inspect Spryker runtime state safely from an AI session | `[AI-DEBUG]` tagged-log pattern plus optional XDebug step-debug; built-in cleanup of debug instrumentation before commit |
+| `project-ci-generator` | Transform an inherited product-style CI setup into a single, lean project CI pipeline | Reads the CI that actually exists rather than applying a template; reuses the discovered commands verbatim so the result stays environment-correct; proposes a keep/drop plan for approval before deleting anything; ports the same jobs to GitLab or Bitbucket |
 
 ## Agents
 


### PR DESCRIPTION
## Summary

Documents the new `project-ci-generator` skill added to the AI Dev SDK. The skill transforms an inherited product/vendor-style CI setup into a single, lean project CI pipeline: it reads the CI that actually exists, runs a short questionnaire, proposes a keep/drop plan for approval, then rebuilds one pipeline from the surviving jobs and prunes unreferenced support files.

Added as a table row on both pages that enumerate the SDK's skills. No dedicated page was created — the other 15 single-purpose skills are documented as table rows only, and `project-ci-generator` is self-contained rather than an orchestrator like `spryker-customization` (which has its own page for its diagram and decision model).

## Related

- Implementation PR: https://github.com/spryker-sdk/ai-dev/pull/27

## Changes

- `docs/dg/dev/ai/ai-dev/ai-dev-skills-and-agents.md` — added `project-ci-generator` to the Skills reference table
- `docs/dg/dev/ai/ai-dev/ai-dev-claude-code-plugin.md` — added the `/spryker-ai-dev-sdk:project-ci-generator` slash command to the plugin Skills table; added `ci` keyword

## Validation

- `vale --minAlertLevel=error` — 0 errors
- `markdownlint-cli2` — 0 errors
- Sidebar checker — no new gaps (no pages added or removed)