### PR TITLE
CC-39898: Document configuration:sync in cloud install recipes

### DIFF
--- a/docs/dg/dev/backend-development/configuration-management.md
+++ b/docs/dg/dev/backend-development/configuration-management.md
@@ -1,7 +1,7 @@
 ---
 title: Configuration Management feature
 description: Learn how to use the Configuration Management feature in a Spryker project.
-last_updated: Apr 27, 2026
+last_updated: Aug 3, 2026
 template: concept-topic-template
 related:
   - title: Install the Configuration Management feature
@@ -784,6 +784,7 @@ For setup instructions, see [Install the Configuration Management feature](/docs
 | `getModuleConfig()` always returns default | Setting `storefront: false` | Yves/Glue can only read storefront-enabled settings. Set `storefront: true` or use Zed Config. |
 | `getModuleConfig()` always returns default | Configuration module not installed | Expected behavior. Method gracefully falls back to `$default`. |
 | Value returns `null` despite being saved | Key mismatch | Compound key format is `feature:tab:group:setting`. Verify all four segments match the YAML schema. |
+| All values return `null` after a deployment, but the Back Office still displays them | Settings map missing in the deployed container | `data/configuration/settings-map.php` and `merged-schema.php` are excluded from the Git repository and the Docker image, so a fresh container has no settings map and every value resolves to `null` before decryption. The Back Office reads the stored row directly, which is why the UI and the runtime resolver disagree. Add `configuration:sync` to the cloud install recipes. See [Install the Configuration Management feature](/docs/dg/dev/integrate-and-configure/integrate-confguration-feature.html). |
 | Secret value empty in Yves | Expected behavior | Secrets are never published to storage. Access only via Zed. |
 | Changes not visible after YAML edit | Schema not synced | Run `configuration:sync` after YAML changes. |
 | Store-specific value not applied | Missing scope context | Pass `ConfigurationScopeTransfer` in third argument or register request expander plugins. See [Adding Custom Scopes](/docs/dg/dev/backend-development/configuration-management/custom-scopes.html). |

--- a/docs/dg/dev/integrate-and-configure/integrate-confguration-feature.md
+++ b/docs/dg/dev/integrate-and-configure/integrate-confguration-feature.md
@@ -1,7 +1,7 @@
 ---
 title: Install the Configuration Management feature
 description: Learn how to integrate and configure Configuration Management feature in a Spryker project.
-last_updated: Apr 27, 2026
+last_updated: Aug 3, 2026
 template: howto-guide-template
 
 related:
@@ -654,7 +654,11 @@ actions:
 
 ### 7) Add install recipe commands
 
-Add the `configuration:sync` command to the install recipe so that the merged schema and settings map are generated during deployment.
+Add the `configuration:sync` command to the install recipes so that the merged schema and settings map are generated during deployment.
+
+The generated files are written to `data/configuration/` inside the container and are excluded from both the Git repository and the Docker image. A freshly deployed container therefore never has them until `configuration:sync` runs. Without these files, the settings map is empty and every configuration value resolves to `null` at runtime—even though the stored values remain intact in the `spy_configuration_value` table. Add the command to every recipe a deployment invokes, not only to the local build recipe.
+
+#### 7.1) Add the command to the local build recipe
 
 **config/install/docker.yml**
 
@@ -668,9 +672,41 @@ Add the command to the `build` section:
             command: 'vendor/bin/console configuration:sync'
 ```
 
+#### 7.2) Add the command to the cloud deployment recipes
+
+Add a `configuration` section to each recipe your deployment pipeline invokes. Place it after the database migration steps and before any `data:import` step: the imported configuration-value rows are validated against the settings map, and the import aborts when the map is missing.
+
+| RECIPE | DEPLOYMENT HOOK |
+| --- | --- |
+| config/install/production.yml | `SPRYKER_HOOK_INSTALL` |
+| config/install/destructive.yml | `SPRYKER_HOOK_DESTRUCTIVE_INSTALL` |
+| config/install/dynamic-store.yml | Dynamic Multistore deployments |
+
+Add the following section to each of the preceding recipes:
+
+```yaml
+    configuration:
+        configuration-sync:
+            command: 'vendor/bin/console configuration:sync -vvv --no-ansi'
+```
+
+If your project clones new environments from a deploy file template, such as `deploy.aws-env-template.yml`, add the section to the template as well so that new environments inherit it.
+
+{% info_block infoBox "pre-deploy recipes" %}
+
+Do not add `configuration:sync` to `config/install/pre-deploy.yml`. This recipe runs before the new code and the database migration are in place, so there is nothing to sync against yet.
+
+{% endinfo_block %}
+
+{% info_block infoBox "Idempotency" %}
+
+Running `configuration:sync` cannot overwrite values set by users. The command only writes the two generated cache files and never opens a database connection, so it is safe to run on every deployment.
+
+{% endinfo_block %}
+
 {% info_block warningBox "Verification" %}
 
-Run the install recipe and verify that the `configuration:sync` step executes without errors.
+Run each install recipe and verify that the `configuration:sync` step executes without errors.
 
 {% endinfo_block %}
 


### PR DESCRIPTION
## Summary

Documents that `configuration:sync` must run in the cloud deployment install recipes, not only in the local `docker.yml` build recipe.

The generated files `data/configuration/settings-map.php` and `merged-schema.php` are excluded from both the Git repository and the Docker image, so a freshly deployed container never has them. Without the settings map, every configuration value resolves to `null` at runtime while the Back Office still displays the stored value — the symptom that looked like a corrupted secret.

## Related

- Implementation PR: https://github.com/spryker-shop/b2b-demo-marketplace/pull/1274
- Ticket: CC-39898

## Changes

- `docs/dg/dev/integrate-and-configure/integrate-confguration-feature.md` — split step 7 into local build recipe (7.1) and cloud deployment recipes (7.2). Documents the `configuration` section for `production.yml`, `destructive.yml`, and `dynamic-store.yml` with their deployment hooks, the placement rule relative to `data:import`, the `pre-deploy.yml` exclusion, and idempotency.
- `docs/dg/dev/backend-development/configuration-management.md` — added a Common Issues row for values resolving to `null` after deployment while the Back Office still shows them.