### PR TITLE
Document extending AI Commerce agents with custom toolsets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,10 @@ Analyze the overall tone to align with technical documentation styles (Google De
 **Spelling:**
 - Use American spelling consistently
 
+**Punctuation:**
+- Always put a space on both sides of an em dash (`—`). Write `covers — for example`, never `covers—for example`.
+- This applies to prose only. Never alter em dashes inside code blocks, inline code, or file paths.
+
 **Terminology (Vale `terms` style):**
 - Use the exact terms enforced by the Vale rules in `vale/styles/terms/`. These are `error`-level and will fail the `vale-lint` CI check.
 - Most common: use **Back Office** (two words), never "Backoffice" or "backoffice". This applies even to API/type names — write **Back Office API**, not "Backoffice API".

--- a/_data/sidebars/dg_dev_sidebar.yml
+++ b/_data/sidebars/dg_dev_sidebar.yml
@@ -64,6 +64,8 @@ entries:
             url: /docs/dg/dev/ai/ai-commerce/ai-commerce-overview.html
           - title: Install AI Commerce
             url: /docs/dg/dev/ai/ai-commerce/install-ai-commerce.html
+          - title: Extend AI Commerce agents with custom toolsets
+            url: /docs/dg/dev/ai/ai-commerce/extend-ai-commerce-agents-with-toolsets.html
           - title: Configure multiple AI providers
             url: /docs/dg/dev/ai/ai-commerce/configure-multiple-ai-providers.html
           - title: Visual Add to Cart

--- a/docs/dg/dev/ai/ai-commerce/ai-commerce-overview.md
+++ b/docs/dg/dev/ai/ai-commerce/ai-commerce-overview.md
@@ -1,7 +1,7 @@
 ---
 title: AI Commerce overview
 description: Technical overview of the AI Commerce SprykerFeature package — architecture, AiFoundation integration, and available features.
-last_updated: Jul 16, 2026
+last_updated: Aug 13, 2026
 template: concept-topic-template
 ---
 
@@ -33,3 +33,7 @@ For the base `AiFoundation` setup, see [Install AI Commerce](/docs/dg/dev/ai/ai-
 ## Installation
 
 To install the AI Commerce base package, see [Install AI Commerce](/docs/dg/dev/ai/ai-commerce/install-ai-commerce.html). Individual features require additional installation steps — see their respective installation guides linked in the table above.
+
+## Customization
+
+To let a feature or agent work with data that no built-in tool covers, add a project-level tool and toolset. For instructions and the security rules that apply, see [Extend AI Commerce agents with custom toolsets](/docs/dg/dev/ai/ai-commerce/extend-ai-commerce-agents-with-toolsets.html).

--- a/docs/dg/dev/ai/ai-commerce/backoffice-assistant/add-custom-backoffice-assistant-agent.md
+++ b/docs/dg/dev/ai/ai-commerce/backoffice-assistant/add-custom-backoffice-assistant-agent.md
@@ -1,11 +1,13 @@
 ---
 title: Add a custom Back Office Assistant agent
 description: Learn how to implement and register a custom agent and toolset for the Back Office Assistant feature, including a dedicated AI configuration and SSE streaming.
-last_updated: Jul 17, 2026
+last_updated: Aug 13, 2026
 template: concept-topic-template
 ---
 
 Back Office Assistant routes each conversation to the most appropriate agent through its intent router. To handle a new domain—for example, managing customers or CMS content—implement a custom agent and register it alongside the built-in agents described in [Back Office Assistant](/docs/dg/dev/ai/ai-commerce/backoffice-assistant/backoffice-assistant.html).
+
+To add tools to an agent or feature that already exists instead of creating a new agent, see [Extend AI Commerce agents with custom toolsets](/docs/dg/dev/ai/ai-commerce/extend-ai-commerce-agents-with-toolsets.html).
 
 ## 1) Implement the agent plugin
 
@@ -136,6 +138,8 @@ class CustomerManagementToolSetPlugin extends AbstractPlugin implements ToolSetP
 ```
 
 Each tool referenced in `getTools()` implements `ToolPluginInterface` from `Spryker\Zed\AiFoundation\Dependency\Tools`, exposing `getName()`, `getDescription()`, `getParameters()`, and `execute()`. The AI model uses `getName()` and `getDescription()` to decide when to call the tool, and `getParameters()` to know which arguments to pass.
+
+For a full tool implementation example and the security rules that apply to every tool you expose, see [Extend AI Commerce agents with custom toolsets](/docs/dg/dev/ai/ai-commerce/extend-ai-commerce-agents-with-toolsets.html).
 
 ## 3) Register the plugins
 

--- a/docs/dg/dev/ai/ai-commerce/content-assistant/smart-cms-content-assistant.md
+++ b/docs/dg/dev/ai/ai-commerce/content-assistant/smart-cms-content-assistant.md
@@ -1,7 +1,7 @@
 ---
 title: Smart CMS Content Assistant
 description: Technical overview of the Smart CMS Content Assistant feature — architecture, AiFoundation integration, plugin structure, and configuration options.
-last_updated: Jun 08, 2026
+last_updated: Aug 13, 2026
 template: concept-topic-template
 ---
 
@@ -36,6 +36,8 @@ The panel collects entity context (name, template, URL slug, key, SEO meta, stor
 | PLUGIN | LOCATION | DESCRIPTION |
 |--------|----------|-------------|
 | `SmartCmsContentToolSetPlugin` | `AiFoundationDependencyProvider::getAiToolSetPlugins()` | Registers the Smart CMS Content Assistant toolset, including the `get_content_items` tool. |
+
+To make additional tools available to the Smart CMS Content Assistant, add your own toolset to `AiCommerceConfig::getSmartCmsToolSetNames()`. For instructions, see [Extend AI Commerce agents with custom toolsets](/docs/dg/dev/ai/ai-commerce/extend-ai-commerce-agents-with-toolsets.html).
 
 Content widget plugins are registered in `AiCommerceDependencyProvider::getContentGuiEditorPlugins()` and are used to resolve available CMS widgets that the AI can reference in generated content:
 

--- a/docs/dg/dev/ai/ai-commerce/extend-ai-commerce-agents-with-toolsets.md
+++ b/docs/dg/dev/ai/ai-commerce/extend-ai-commerce-agents-with-toolsets.md
@@ -93,7 +93,7 @@ class GetProductToolPlugin extends AbstractPlugin implements ToolPluginInterface
     public function getParameters(): array
     {
         return [
-            new ToolParameter(static::PARAMETER_SKU, 'string', 'The SKU of the product to look up, for example "093_24495843".', true),
+            new ToolParameter(static::PARAMETER_SKU, 'string', 'The SKU of the product to look up, for example "001_25904006".', true),
         ];
     }
 
@@ -280,14 +280,8 @@ A system prompt is a guideline, not a security control. The model can be steered
 
 ## 7) Verify the toolset
 
-1. Clear the cache and run the setup:
-
-```bash
-console cache:empty-all
-```
-
-2. Trigger the feature you enabled the toolset for, with a request that requires the new tool.
-3. Check the AI interaction audit log to confirm the tool was called with the expected arguments. For details, see [AI Interaction Audit Logs](/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.html).
+1. Trigger the feature you enabled the toolset for, with a request that requires the new tool.
+2. Check the AI interaction audit log to confirm the tool was called with the expected arguments. For details, see [AI Interaction Audit Logs](/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.html).
 
 If the tool is never called, verify the following:
 

--- a/docs/dg/dev/ai/ai-commerce/extend-ai-commerce-agents-with-toolsets.md
+++ b/docs/dg/dev/ai/ai-commerce/extend-ai-commerce-agents-with-toolsets.md
@@ -1,0 +1,296 @@
+---
+title: Extend AI Commerce agents with custom toolsets
+description: Learn how to add project-level tools and toolsets that let AI Commerce agents read and change your own data, and how to do it safely.
+last_updated: Aug 13, 2026
+template: howto-guide-template
+---
+
+AI Commerce agents can only act on data that a *tool* exposes to them. A tool is a PHP class the AI model calls with arguments and gets a result back. Tools are grouped into named *toolsets*, and each agent or feature declares which toolsets it uses.
+
+To let an agent work with data that no built-in tool covers—for example, your own entity—implement a tool, group it in a toolset, register the toolset, and add the toolset name to the feature that must use it.
+
+This document describes how to extend an existing agent or feature. To add a completely new agent, see [Add a custom Back Office Assistant agent](/docs/dg/dev/ai/ai-commerce/backoffice-assistant/add-custom-backoffice-assistant-agent.html).
+
+## How toolsets are resolved
+
+Every prompt request carries a list of toolset names. At runtime, AiFoundation matches those names against the toolset plugins registered in `AiFoundationDependencyProvider::getAiToolSetPlugins()` and passes the merged tools of all matching toolsets to the AI provider.
+
+Two things follow from this:
+
+- A toolset is only available to a feature if the feature's toolset name list contains its name. Registering the plugin alone does nothing.
+- A toolset name that does not match a registered plugin is ignored without an error. If your tool is never called, first check that the name in the configuration matches `getName()` exactly.
+
+Features expose their toolset names differently:
+
+| FEATURE | WHERE TOOLSET NAMES COME FROM |
+|---------|-------------------------------|
+| Smart CMS Content Assistant | `AiCommerceConfig::getSmartCmsToolSetNames()`. Override it in `Pyz` to add names. |
+| Back Office Assistant agents | Each agent plugin calls `PromptRequestTransfer::addToolSetName()` in `executeAgent()`. To change the list of an existing agent, override that agent plugin in `Pyz`. |
+
+{% info_block warningBox "Security" %}
+
+A tool is executable code that the AI model decides when to call, based on a model-generated argument list. Treat every tool as an untrusted, publicly reachable entry point:
+
+- **Prefer read-only tools.** Only expose write, update, or delete operations when the use case genuinely requires them. A prompt injected through user-generated content—a product description, a customer note, an uploaded file—can make the model call any tool that is available to it.
+- **Validate and constrain every argument.** The model can pass any value that fits the declared type. Validate arguments in `execute()` exactly as you would validate a request from the internet.
+- **Enforce permissions inside the tool.** Tool execution does not inherit the Back Office user's ACL rules. Check permissions explicitly in `execute()` for anything sensitive.
+- **Never return personal or secret data.** Everything a tool returns is sent to the AI provider and stored in the conversation history. Return only the fields the agent needs, and exclude credentials, tokens, and personal data.
+- **Limit result size.** Apply a pagination limit, as `getSmartCmsContentItemLookupLimit()` does for Smart CMS, so a single call cannot send your entire catalog to the provider.
+- **Catch exceptions.** Return a neutral error string instead of letting an exception surface, so internal details such as stack traces or table names are not exposed to the model.
+
+{% endinfo_block %}
+
+## 1) Implement the tool plugin
+
+Create a plugin that implements `ToolPluginInterface` from `Spryker\Zed\AiFoundation\Dependency\Tools`:
+
+| METHOD | PURPOSE |
+|--------|---------|
+| `getName()` | Returns the unique tool name the model uses to call the tool. |
+| `getDescription()` | Describes what the tool does and when to use it. The model relies on this text to decide whether to call the tool, so be specific. |
+| `getParameters()` | Returns the accepted parameters as `ToolParameter` objects, each with a name, a type (`string`, `integer`, `number`, `boolean`, `array`, or `object`), a description, and a required flag. |
+| `execute()` | Runs the tool and returns the result. Return a JSON-encoded string so the model can parse the result reliably. |
+
+The following read-only tool returns a single product by SKU:
+
+**src/Pyz/Zed/AiCommerce/Communication/Plugin/AiFoundation/Tool/GetProductToolPlugin.php**
+
+```php
+<?php
+
+namespace Pyz\Zed\AiCommerce\Communication\Plugin\AiFoundation\Tool;
+
+use Spryker\Shared\Log\LoggerTrait;
+use Spryker\Zed\AiFoundation\Dependency\Tools\ToolParameter;
+use Spryker\Zed\AiFoundation\Dependency\Tools\ToolPluginInterface;
+use Spryker\Zed\Kernel\Communication\AbstractPlugin;
+use Throwable;
+
+/**
+ * @method \Pyz\Zed\AiCommerce\Business\AiCommerceFacadeInterface getFacade()
+ */
+class GetProductToolPlugin extends AbstractPlugin implements ToolPluginInterface
+{
+    use LoggerTrait;
+
+    protected const string TOOL_NAME = 'get_product';
+
+    protected const string PARAMETER_SKU = 'sku';
+
+    public function getName(): string
+    {
+        return static::TOOL_NAME;
+    }
+
+    public function getDescription(): string
+    {
+        return 'Returns the name, status, and price of a single product identified by its SKU. Use when the user asks about a specific product.';
+    }
+
+    /**
+     * @return array<\Spryker\Zed\AiFoundation\Dependency\Tools\ToolParameterInterface>
+     */
+    public function getParameters(): array
+    {
+        return [
+            new ToolParameter(static::PARAMETER_SKU, 'string', 'The SKU of the product to look up, for example "093_24495843".', true),
+        ];
+    }
+
+    public function execute(...$arguments): mixed
+    {
+        $sku = $arguments[static::PARAMETER_SKU] ?? null;
+
+        if (!is_string($sku) || $sku === '') {
+            return (string)json_encode(['error' => 'A non-empty sku is required.']);
+        }
+
+        try {
+            $productConcreteTransfer = $this->getFacade()->findProductBySku($sku);
+
+            if ($productConcreteTransfer === null) {
+                return (string)json_encode(['error' => 'Product not found.']);
+            }
+
+            return (string)json_encode([
+                'sku' => $productConcreteTransfer->getSku(),
+                'name' => $productConcreteTransfer->getName(),
+                'isActive' => $productConcreteTransfer->getIsActive(),
+            ]);
+        } catch (Throwable $throwable) {
+            $this->getLogger()->error('GetProductToolPlugin::execute() failed.', ['exception' => $throwable]);
+
+            return (string)json_encode(['error' => 'An error occurred while retrieving the product.']);
+        }
+    }
+}
+```
+
+The tool validates the SKU before use, returns only three fields, and converts any exception into a neutral message. Apply the same three rules to every tool you add.
+
+{% info_block warningBox "Warning" %}
+
+If you expose write operations—creating, updating, or deleting data—the model can trigger them without a human confirming the action. Restrict such tools to non-critical entities, validate every argument against an allowlist of permitted values, and check the acting user's permissions inside `execute()`.
+
+{% endinfo_block %}
+
+## 2) Add a factory method for the tool
+
+Add a method that creates the tool to your project's communication factory:
+
+**src/Pyz/Zed/AiCommerce/Communication/AiCommerceCommunicationFactory.php**
+
+```php
+<?php
+
+namespace Pyz\Zed\AiCommerce\Communication;
+
+use Pyz\Zed\AiCommerce\Communication\Plugin\AiFoundation\Tool\GetProductToolPlugin;
+use Spryker\Zed\AiFoundation\Dependency\Tools\ToolPluginInterface;
+use SprykerFeature\Zed\AiCommerce\Communication\AiCommerceCommunicationFactory as SprykerFeatureAiCommerceCommunicationFactory;
+
+class AiCommerceCommunicationFactory extends SprykerFeatureAiCommerceCommunicationFactory
+{
+    public function createGetProductToolPlugin(): ToolPluginInterface
+    {
+        return new GetProductToolPlugin();
+    }
+}
+```
+
+## 3) Implement the toolset plugin
+
+Group the tools in a toolset by implementing `ToolSetPluginInterface` from `Spryker\Zed\AiFoundation\Dependency\Tools`. Group tools that belong to the same domain, so an agent can enable them together:
+
+**src/Pyz/Zed/AiCommerce/Communication/Plugin/AiFoundation/ProductInfoToolSetPlugin.php**
+
+```php
+<?php
+
+namespace Pyz\Zed\AiCommerce\Communication\Plugin\AiFoundation;
+
+use Spryker\Zed\AiFoundation\Dependency\Tools\ToolSetPluginInterface;
+use Spryker\Zed\Kernel\Communication\AbstractPlugin;
+
+/**
+ * @method \Pyz\Zed\AiCommerce\Communication\AiCommerceCommunicationFactory getFactory()
+ */
+class ProductInfoToolSetPlugin extends AbstractPlugin implements ToolSetPluginInterface
+{
+    protected const string TOOL_SET_PRODUCT_INFO = 'product_info_tools';
+
+    public function getName(): string
+    {
+        return static::TOOL_SET_PRODUCT_INFO;
+    }
+
+    /**
+     * @return array<\Spryker\Zed\AiFoundation\Dependency\Tools\ToolPluginInterface>
+     */
+    public function getTools(): array
+    {
+        return [
+            $this->getFactory()->createGetProductToolPlugin(),
+        ];
+    }
+}
+```
+
+## 4) Register the toolset plugin
+
+Add the toolset plugin to the array returned by `AiFoundationDependencyProvider::getAiToolSetPlugins()`:
+
+**src/Pyz/Zed/AiFoundation/AiFoundationDependencyProvider.php**
+
+```php
+<?php
+
+namespace Pyz\Zed\AiFoundation;
+
+use Pyz\Zed\AiCommerce\Communication\Plugin\AiFoundation\ProductInfoToolSetPlugin;
+use Spryker\Zed\AiFoundation\AiFoundationDependencyProvider as SprykerAiFoundationDependencyProvider;
+
+class AiFoundationDependencyProvider extends SprykerAiFoundationDependencyProvider
+{
+    /**
+     * @return array<\Spryker\Zed\AiFoundation\Dependency\Tools\ToolSetPluginInterface>
+     */
+    protected function getAiToolSetPlugins(): array
+    {
+        return [
+            // ... existing toolset plugins
+            new ProductInfoToolSetPlugin(),
+        ];
+    }
+}
+```
+
+## 5) Enable the toolset for a feature
+
+Registering the plugin makes the toolset resolvable, but a feature only receives its tools once the toolset name is in the feature's list.
+
+### Smart CMS Content Assistant
+
+Override `getSmartCmsToolSetNames()` in your project configuration and keep the built-in names, so the content item lookup tool stays available:
+
+**src/Pyz/Zed/AiCommerce/AiCommerceConfig.php**
+
+```php
+<?php
+
+namespace Pyz\Zed\AiCommerce;
+
+use SprykerFeature\Zed\AiCommerce\AiCommerceConfig as SprykerFeatureAiCommerceConfig;
+
+class AiCommerceConfig extends SprykerFeatureAiCommerceConfig
+{
+    /**
+     * @uses \Pyz\Zed\AiCommerce\Communication\Plugin\AiFoundation\ProductInfoToolSetPlugin::TOOL_SET_PRODUCT_INFO
+     *
+     * @return array<string>
+     */
+    public function getSmartCmsToolSetNames(): array
+    {
+        return array_merge(parent::getSmartCmsToolSetNames(), [
+            'product_info_tools',
+        ]);
+    }
+}
+```
+
+### Back Office Assistant agents
+
+Built-in agents add their toolset names in `executeAgent()`. To give an existing agent an additional toolset, extend that agent plugin in `Pyz`, add the extra name, and register your plugin instead of the built-in one in `AiCommerceDependencyProvider::getBackofficeAssistantAgentPlugins()`. For instructions on registering agent plugins, see [Add a custom Back Office Assistant agent](/docs/dg/dev/ai/ai-commerce/backoffice-assistant/add-custom-backoffice-assistant-agent.html).
+
+## 6) Adjust the system prompt
+
+Tools alone do not guarantee the model uses them as intended. The system prompt sets the rules the model follows when it decides which tool to call, so review it whenever you add tools.
+
+`AiCommerceConfig` exposes the prompt templates for the Smart PIM features—translation, category suggestion, content improvement, and image alt text—through methods such as `getContentImproverPromptTemplate()`. Each reads a Configuration Management value and falls back to the built-in template when the value is empty. Override the corresponding method or set the configuration value to state which tool to use, when to use it, and what the model must never do with the returned data.
+
+Keep the placeholders of the original template. Removing a `%s` placeholder breaks the `sprintf()` call that builds the final prompt.
+
+Because prompts are resolved per AI configuration, a prompt change affects every feature bound to that configuration. For how features map to configurations and providers, see [Configure multiple AI providers for AI Commerce](/docs/dg/dev/ai/ai-commerce/configure-multiple-ai-providers.html).
+
+{% info_block warningBox "Warning" %}
+
+A system prompt is a guideline, not a security control. The model can be steered away from prompt instructions by injected content, so never rely on the prompt alone to prevent a tool from being misused. Enforce every restriction that matters in the tool's `execute()` method.
+
+{% endinfo_block %}
+
+## 7) Verify the toolset
+
+1. Clear the cache and run the setup:
+
+```bash
+console cache:empty-all
+```
+
+2. Trigger the feature you enabled the toolset for, with a request that requires the new tool.
+3. Check the AI interaction audit log to confirm the tool was called with the expected arguments. For details, see [AI Interaction Audit Logs](/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.html).
+
+If the tool is never called, verify the following:
+
+- The toolset name in the feature configuration matches the toolset plugin's `getName()` exactly.
+- The toolset plugin is registered in `AiFoundationDependencyProvider::getAiToolSetPlugins()`.
+- The tool description states clearly when the tool applies. A vague description is the most common reason a model ignores a tool.

--- a/docs/dg/dev/ai/ai-commerce/extend-ai-commerce-agents-with-toolsets.md
+++ b/docs/dg/dev/ai/ai-commerce/extend-ai-commerce-agents-with-toolsets.md
@@ -134,31 +134,7 @@ If you expose write operations — creating, updating, or deleting data — the 
 
 {% endinfo_block %}
 
-## 2) Add a factory method for the tool
-
-Add a method that creates the tool to your project's communication factory:
-
-**src/Pyz/Zed/AiCommerce/Communication/AiCommerceCommunicationFactory.php**
-
-```php
-<?php
-
-namespace Pyz\Zed\AiCommerce\Communication;
-
-use Pyz\Zed\AiCommerce\Communication\Plugin\AiFoundation\Tool\GetProductToolPlugin;
-use Spryker\Zed\AiFoundation\Dependency\Tools\ToolPluginInterface;
-use SprykerFeature\Zed\AiCommerce\Communication\AiCommerceCommunicationFactory as SprykerFeatureAiCommerceCommunicationFactory;
-
-class AiCommerceCommunicationFactory extends SprykerFeatureAiCommerceCommunicationFactory
-{
-    public function createGetProductToolPlugin(): ToolPluginInterface
-    {
-        return new GetProductToolPlugin();
-    }
-}
-```
-
-## 3) Implement the toolset plugin
+## 2) Implement the toolset plugin
 
 Group the tools in a toolset by implementing `ToolSetPluginInterface` from `Spryker\Zed\AiFoundation\Dependency\Tools`. Group tools that belong to the same domain, so an agent can enable them together:
 
@@ -169,12 +145,10 @@ Group the tools in a toolset by implementing `ToolSetPluginInterface` from `Spry
 
 namespace Pyz\Zed\AiCommerce\Communication\Plugin\AiFoundation;
 
+use Pyz\Zed\AiCommerce\Communication\Plugin\AiFoundation\Tool\GetProductToolPlugin;
 use Spryker\Zed\AiFoundation\Dependency\Tools\ToolSetPluginInterface;
 use Spryker\Zed\Kernel\Communication\AbstractPlugin;
 
-/**
- * @method \Pyz\Zed\AiCommerce\Communication\AiCommerceCommunicationFactory getFactory()
- */
 class ProductInfoToolSetPlugin extends AbstractPlugin implements ToolSetPluginInterface
 {
     protected const string TOOL_SET_PRODUCT_INFO = 'product_info_tools';
@@ -190,13 +164,13 @@ class ProductInfoToolSetPlugin extends AbstractPlugin implements ToolSetPluginIn
     public function getTools(): array
     {
         return [
-            $this->getFactory()->createGetProductToolPlugin(),
+            new GetProductToolPlugin(),
         ];
     }
 }
 ```
 
-## 4) Register the toolset plugin
+## 3) Register the toolset plugin
 
 Add the toolset plugin to the array returned by `AiFoundationDependencyProvider::getAiToolSetPlugins()`:
 
@@ -225,7 +199,7 @@ class AiFoundationDependencyProvider extends SprykerAiFoundationDependencyProvid
 }
 ```
 
-## 5) Enable the toolset for a feature
+## 4) Enable the toolset for a feature
 
 Registering the plugin makes the toolset resolvable, but a feature only receives its tools once the toolset name is in the feature's list.
 
@@ -262,7 +236,7 @@ class AiCommerceConfig extends SprykerFeatureAiCommerceConfig
 
 Built-in agents add their toolset names in `executeAgent()`. To give an existing agent an additional toolset, extend that agent plugin in `Pyz`, add the extra name, and register your plugin instead of the built-in one in `AiCommerceDependencyProvider::getBackofficeAssistantAgentPlugins()`. For instructions on registering agent plugins, see [Add a custom Back Office Assistant agent](/docs/dg/dev/ai/ai-commerce/backoffice-assistant/add-custom-backoffice-assistant-agent.html).
 
-## 6) Adjust the system prompt
+## 5) Adjust the system prompt
 
 Tools alone do not guarantee the model uses them as intended. The system prompt sets the rules the model follows when it decides which tool to call, so review it whenever you add tools.
 
@@ -278,7 +252,7 @@ A system prompt is a guideline, not a security control. The model can be steered
 
 {% endinfo_block %}
 
-## 7) Verify the toolset
+## 6) Verify the toolset
 
 1. Trigger the feature you enabled the toolset for, with a request that requires the new tool.
 2. Check the AI interaction audit log to confirm the tool was called with the expected arguments. For details, see [AI Interaction Audit Logs](/docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.html).

--- a/docs/dg/dev/ai/ai-commerce/extend-ai-commerce-agents-with-toolsets.md
+++ b/docs/dg/dev/ai/ai-commerce/extend-ai-commerce-agents-with-toolsets.md
@@ -7,7 +7,7 @@ template: howto-guide-template
 
 AI Commerce agents can only act on data that a *tool* exposes to them. A tool is a PHP class the AI model calls with arguments and gets a result back. Tools are grouped into named *toolsets*, and each agent or feature declares which toolsets it uses.
 
-To let an agent work with data that no built-in tool covers—for example, your own entity—implement a tool, group it in a toolset, register the toolset, and add the toolset name to the feature that must use it.
+To let an agent work with data that no built-in tool covers — for example, your own entity — implement a tool, group it in a toolset, register the toolset, and add the toolset name to the feature that must use it.
 
 This document describes how to extend an existing agent or feature. To add a completely new agent, see [Add a custom Back Office Assistant agent](/docs/dg/dev/ai/ai-commerce/backoffice-assistant/add-custom-backoffice-assistant-agent.html).
 
@@ -31,7 +31,7 @@ Features expose their toolset names differently:
 
 A tool is executable code that the AI model decides when to call, based on a model-generated argument list. Treat every tool as an untrusted, publicly reachable entry point:
 
-- **Prefer read-only tools.** Only expose write, update, or delete operations when the use case genuinely requires them. A prompt injected through user-generated content—a product description, a customer note, an uploaded file—can make the model call any tool that is available to it.
+- **Prefer read-only tools.** Only expose write, update, or delete operations when the use case genuinely requires them. A prompt injected through user-generated content — a product description, a customer note, an uploaded file — can make the model call any tool that is available to it.
 - **Validate and constrain every argument.** The model can pass any value that fits the declared type. Validate arguments in `execute()` exactly as you would validate a request from the internet.
 - **Enforce permissions inside the tool.** Tool execution does not inherit the Back Office user's ACL rules. Check permissions explicitly in `execute()` for anything sensitive.
 - **Never return personal or secret data.** Everything a tool returns is sent to the AI provider and stored in the conversation history. Return only the fields the agent needs, and exclude credentials, tokens, and personal data.
@@ -130,7 +130,7 @@ The tool validates the SKU before use, returns only three fields, and converts a
 
 {% info_block warningBox "Warning" %}
 
-If you expose write operations—creating, updating, or deleting data—the model can trigger them without a human confirming the action. Restrict such tools to non-critical entities, validate every argument against an allowlist of permitted values, and check the acting user's permissions inside `execute()`.
+If you expose write operations — creating, updating, or deleting data — the model can trigger them without a human confirming the action. Restrict such tools to non-critical entities, validate every argument against an allowlist of permitted values, and check the acting user's permissions inside `execute()`.
 
 {% endinfo_block %}
 
@@ -266,7 +266,7 @@ Built-in agents add their toolset names in `executeAgent()`. To give an existing
 
 Tools alone do not guarantee the model uses them as intended. The system prompt sets the rules the model follows when it decides which tool to call, so review it whenever you add tools.
 
-`AiCommerceConfig` exposes the prompt templates for the Smart PIM features—translation, category suggestion, content improvement, and image alt text—through methods such as `getContentImproverPromptTemplate()`. Each reads a Configuration Management value and falls back to the built-in template when the value is empty. Override the corresponding method or set the configuration value to state which tool to use, when to use it, and what the model must never do with the returned data.
+`AiCommerceConfig` exposes the prompt templates for the Smart PIM features — translation, category suggestion, content improvement, and image alt text — through methods such as `getContentImproverPromptTemplate()`. Each reads a Configuration Management value and falls back to the built-in template when the value is empty. Override the corresponding method or set the configuration value to state which tool to use, when to use it, and what the model must never do with the returned data.
 
 Keep the placeholders of the original template. Removing a `%s` placeholder breaks the `sprintf()` call that builds the final prompt.
 

--- a/docs/dg/dev/ai/ai-foundation/ai-foundation-tool-support.md
+++ b/docs/dg/dev/ai/ai-foundation/ai-foundation-tool-support.md
@@ -1,7 +1,7 @@
 ---
 title: Use AI tools with the AiFoundation module
 description: Extend AI capabilities by providing custom tools that AI models can invoke during conversations
-last_updated: Apr 29, 2026
+last_updated: Aug 13, 2026
 keywords: foundation, ai, tools, function calling, tool sets, plugins, openai, anthropic, prompt, agent, audit, logging
 template: howto-guide-template
 related:
@@ -13,6 +13,8 @@ related:
     link: docs/dg/dev/ai/ai-foundation/ai-foundation-workflow-state-machine.html
   - title: AI Interaction Audit Logs
     link: docs/dg/dev/ai/ai-foundation/ai-foundation-audit-logs.html
+  - title: Extend AI Commerce agents with custom toolsets
+    link: docs/dg/dev/ai/ai-commerce/extend-ai-commerce-agents-with-toolsets.html
 ---
 
 This document describes how to create and use AI tools with the AiFoundation module to extend AI capabilities by providing custom functions that AI models can invoke during conversations.
@@ -621,3 +623,4 @@ Monitor token consumption when using tools extensively.
 
 - [AiFoundation module Overview](/docs/dg/dev/ai/ai-foundation/ai-foundation-module.html)
 - [Use structured responses with the AiFoundation module](/docs/dg/dev/ai/ai-foundation/ai-foundation-transfer-response.html)
+- [Extend AI Commerce agents with custom toolsets](/docs/dg/dev/ai/ai-commerce/extend-ai-commerce-agents-with-toolsets.html)


### PR DESCRIPTION
## Summary

Adds a new developer guide describing how to extend AI Commerce agents and features with project-level tools and toolsets — for example, exposing a read-only product lookup, or full CRUD, to the Smart CMS Content Assistant or a Back Office Assistant agent.

The existing [Add a custom Back Office Assistant agent](https://docs.spryker.com/docs/dg/dev/ai/ai-commerce/backoffice-assistant/add-custom-backoffice-assistant-agent.html) page covers building a whole new agent. This page covers the complementary case: adding tools to agents and features that already exist.

## Changes

- Created: `docs/dg/dev/ai/ai-commerce/extend-ai-commerce-agents-with-toolsets.md`
- Updated: `_data/sidebars/dg_dev_sidebar.yml` — entry added after **Install AI Commerce**

## Contents

- How toolset names are resolved at runtime, and why an unmatched name fails silently
- Where each feature gets its toolset names from (`AiCommerceConfig::getSmartCmsToolSetNames()`, agent `addToolSetName()` calls)
- Step-by-step: tool plugin → factory method → toolset plugin → registration → enabling it per feature
- **Security warning block** covering prompt injection via tools, preferring read-only tools, argument validation, permission checks inside `execute()`, data leakage to the AI provider, and result-size limits
- System prompt guidance, cross-referencing [Configure multiple AI providers](https://docs.spryker.com/docs/dg/dev/ai/ai-commerce/configure-multiple-ai-providers.html), with a warning that prompts are not a security control
- Verification steps and a troubleshooting list

All code examples are derived from the actual `AiFoundation` / `AiCommerce` interfaces (`ToolPluginInterface`, `ToolSetPluginInterface`, `ToolParameter`) — no invented APIs.

## Validation

- `vale --minAlertLevel=error` — 0 errors
- `markdownlint-cli2` — 0 errors
- `sidebar_checker.sh` — no findings for the new page
- All internal links verified to resolve

## Related

No ticket.