### PR TITLE
CC-39888 Document the API Platform test harness

### DIFF
--- a/_data/sidebars/integrations.yml
+++ b/_data/sidebars/integrations.yml
@@ -70,6 +70,8 @@ entries:
           url: /docs/integrations/spryker-api/api-platform/native-api-platform-resources.html
         - title: Test API Platform resources
           url: /docs/integrations/spryker-api/api-platform/testing.html
+        - title: Prove API Platform contract coverage
+          url: /docs/integrations/spryker-api/api-platform/contract-coverage.html
         - title: IDE integration
           url: /docs/integrations/spryker-api/api-platform/ide-integration.html
         - title: Troubleshooting

--- a/docs/integrations/spryker-api/api-platform/contract-coverage.md
+++ b/docs/integrations/spryker-api/api-platform/contract-coverage.md
@@ -1,0 +1,146 @@
+---
+title: Prove API Platform contract coverage
+description: Declare which API Platform operations and validation rules your tests cover, and let a CI gate fail the build on any gap.
+last_updated: Aug 17, 2026
+template: howto-guide-template
+related:
+  - title: Test API Platform resources
+    link: docs/integrations/spryker-api/api-platform/testing.html
+  - title: Resource schemas
+    link: docs/integrations/spryker-api/api-platform/resource-schemas.html
+  - title: Validation schemas
+    link: docs/integrations/spryker-api/api-platform/validation-schemas.html
+  - title: API Platform
+    link: docs/integrations/spryker-api/api-platform/api-platform.html
+---
+
+Contract coverage turns "the tests pass" into "every operation and validation rule this resource declares has a test that asserts on it". You declare what a test covers with two attributes, and a CI gate diffs those declarations against the generated resource classes.
+
+This gives you two things a green test run alone does not:
+
+- A reviewer reading a test method sees the verb, the URL, and the validation rule it exercises, without reading the body.
+- The build fails when a resource gains an operation or a validation rule that no test covers.
+
+## Annotate a test
+
+Declare the one operation the test asserts on. Do not declare the requests the arrange step makes. Import the attributes and write them as short names:
+
+```php
+#[CoversApiOperation('POST', '/wishlists')]
+#[CoversApiValidation('wishlists', 'name', Rule::NOT_BLANK)]
+public function testGivenABlankNameWhenPostWishlistThenItRespondsUnprocessableEntity(): void
+```
+
+`CoversApiOperation(verb, uriTemplate)` takes the OpenAPI `uriTemplate`, such as `/wishlists/{wishlistUuid}/wishlist-items`. Without a `status`, it covers the operation's success response. With one, it declares the error response the test asserts on:
+
+```php
+#[CoversApiOperation('GET', '/wishlists/{uuid}', status: Response::HTTP_NOT_FOUND)]
+```
+
+`CoversApiValidation(resource, attribute, rule)` takes the resource short name, the guarded attribute, and a `Rule` identifier such as `Rule::NOT_BLANK` or `Rule::LENGTH_MAX`. It binds to the `CoversApiOperation` on the same method, which names the operation the rule was exercised against. Never put it on a method that has no `CoversApiOperation`.
+
+Both attributes are repeatable, but keep one asserted operation per test method.
+
+## Validation coverage is per operation
+
+Whether a constraint fires depends on the operation's validation groups. The truth set holds one entry per rule per input operation—`POST`, `PUT`, `PATCH`—whose groups intersect the constraint's groups. Both default to `Default`, mirroring Symfony.
+
+For example, a wishlist name's `NotBlank` carries both the create and the update group, so `POST /wishlists` and `PATCH /wishlists/{uuid}` each need their own annotated test. A wishlist item's `sku` `NotBlank` carries only the create group, so it needs a `POST` test and no `PATCH` test.
+
+## Responses come from the resource schema
+
+The gate never invents an error response. Every status a resource schema declares under `openapiContext.responses` becomes one coverage item that a test must claim:
+
+```yaml
+- type: GetCollection
+  uriTemplate: /abstract-products/{abstractProductSku}/abstract-product-image-sets
+  description: 'Retrieve image sets of an abstract product'
+  openapiContext:
+      responses:
+          200:
+              description: 'Image sets of the abstract product returned.'
+          404:
+              description: 'No abstract product exists for the given SKU.'
+```
+
+An enforced operation that declares no responses at all is reported as a schema defect, naming the `.resource.yml` to fix. So declaring your responses is the first step of adopting a resource, not an afterthought.
+
+Validation coverage stays separate from this. A declared `422` demands one test for the status, and every constraint active on the operation additionally demands its own test.
+
+### Do not declare a response the router cannot reach
+
+A provider that answers `400` for a missing path segment is unreachable on a nested `uriTemplate`. The router never matches such a template with an empty segment, so a segment-less call falls through to the collection operation instead. Declaring that `400` creates a coverage item no test can ever satisfy.
+
+Given a provider that guards against a missing `{attributeKey}`, the operation at `/product-management-attributes/{attributeKey}` must not declare `400`—a key-less call lands on `/product-management-attributes` instead. The same holds for every operation nested under a parent identifier, such as `{abstractProductSku}` or `{concreteProductSku}`.
+
+Declare only the statuses a client can actually observe.
+
+### Operations that cannot be asserted on
+
+An item `GET` with no provider—neither on the operation nor on the resource—is classified as non-servable. With nothing to read, it only mints IRIs and answers `200 null`, so no integration test can assert on it. The gate reports these separately and does not count them as gaps.
+
+## Two guarantees
+
+Declarations are verified, not claimed. The base test case records every operation a booted request actually matches, and fails the test when a declared operation was never dispatched. You cannot annotate an operation your test does not exercise.
+
+In-scope resources have no gaps. The report diffs the generated `#[ApiResource]` classes against the collected annotations and fails the build on any uncovered operation, any uncovered validation rule, and any stale claim that points at something the schema no longer defines.
+
+## Run the report
+
+```bash
+GLUE_APPLICATION=GLUE_STOREFRONT vendor/bin/glue api:contract:coverage
+```
+
+The command prints covered, uncovered, and stale entries for operations and validation rules, lists non-servable operations, and exits non-zero when the gate fails. Add `-v` to list every covered entry.
+
+Narrow it to what you are working on with `--module` or `-m`. Casing, separators, and a trailing plural are all ignored, so the module name and the resource short name both work:
+
+```bash
+vendor/bin/glue api:contract:coverage -m Wishlist                      # the wishlists resource
+vendor/bin/glue api:contract:coverage -m WishlistItems                 # the wishlist-items resource
+vendor/bin/glue api:contract:coverage -m wishlists -m wishlist-items   # both
+```
+
+Matching is exact once normalized, so `-m Wishlist` selects `wishlists` only and does not pull in `wishlist-items`. A filter naming no known resource fails the command and lists what is selectable, so a typo cannot quietly report on nothing.
+
+Narrowing changes only what the run enforces. Scope drift is a property of the whole repository and is always checked against the full list.
+
+### Prerequisites
+
+The command is development-only, because it reads the coverage annotations off your test suites. It is registered only when development console commands are enabled:
+
+```bash
+DEVELOPMENT_CONSOLE_COMMANDS=1
+```
+
+It also needs the resources generated first:
+
+```bash
+GLUE_APPLICATION=GLUE_STOREFRONT vendor/bin/glue api:generate
+```
+
+`api:generate` is a Glue console command, so use `vendor/bin/glue` and not `vendor/bin/console`.
+
+The check itself is boot-free—it reflects generated classes and test attributes, and reads no database.
+
+## In CI
+
+The `Standard Validation` job runs the gate and writes the gaps to the run summary, so a failure is readable without expanding the step:
+
+```bash
+vendor/bin/glue api:contract:coverage --summary-out "$GITHUB_STEP_SUMMARY"
+```
+
+The suites themselves run in a separate job. For that side, see [Test API Platform resources](/docs/integrations/spryker-api/api-platform/testing.html).
+
+## Adopt a resource
+
+Coverage is enforced for the resources the gate's scope names. Adopting one means:
+
+1. Declare the resource's real responses under `openapiContext.responses` in its `.resource.yml`.
+2. Add the annotated tests that cover its servable operations and validation rules.
+3. Add the resource to the enforced scope.
+
+A drift gate protects step 3. When an annotated test references a resource outside the enforced scope, the build fails with an unscoped-resource error, so you cannot annotate a resource's tests and forget to enforce it.
+
+Both resources and tests are discovered automatically, so adding a test never requires editing the tool.

--- a/docs/integrations/spryker-api/api-platform/resource-schemas.md
+++ b/docs/integrations/spryker-api/api-platform/resource-schemas.md
@@ -1,7 +1,7 @@
 ---
 title: Resource schemas
 description: Understanding API Platform resource schema definitions in Spryker.
-last_updated: Jul 31, 2026
+last_updated: Aug 17, 2026
 template: concept-topic-template
 related:
   - title: API Platform

--- a/docs/integrations/spryker-api/api-platform/resource-schemas.md
+++ b/docs/integrations/spryker-api/api-platform/resource-schemas.md
@@ -259,6 +259,18 @@ customerReference:
   identifier: true  # URL becomes /customers/{customerReference}
 ```
 
+In a JSON:API response, the identifier is what fills `data.id`. It is therefore not an attribute, and combining `identifier: true` with `readable: false` keeps it out of the `attributes` block:
+
+```yaml
+uuid:
+  type: string
+  identifier: true
+  readable: false
+  writable: false
+```
+
+That combination is what reproduces the legacy Glue response shape, where the UUID appears as `data.id` and never inside `attributes`. Leave `readable` at its default and the same value is serialized twice—once as `data.id` and once as an attribute—which is a breaking change for clients that were written against the legacy shape.
+
 #### required
 
 Makes property mandatory (use validation schemas for detailed rules):
@@ -971,6 +983,22 @@ The operation names map to HTTP methods:
 - `put` → PUT (replace)
 - `patch` → PATCH (update)
 - `delete` → DELETE (remove)
+
+### Write-only resources need `gen_id: false`
+
+Serializing a created representation normally includes an IRI pointing at the new resource, which the serializer builds from the resource's item operation. A resource that declares only a `Post` and no `Get` has no item operation, so there is no IRI to build and the success response fails to serialize.
+
+Turn the ID generation off for that operation:
+
+```yaml
+operations:
+  - type: Post
+    description: 'Initialize a pre-order payment'
+    normalizationContext:
+        gen_id: false
+```
+
+This applies to action-shaped resources—payments, cancellations, and similar endpoints that accept a command and return a result rather than exposing a retrievable entity.
 
 ## Pagination
 

--- a/docs/integrations/spryker-api/api-platform/testing.md
+++ b/docs/integrations/spryker-api/api-platform/testing.md
@@ -943,6 +943,8 @@ Each tier needs a stack of helpers in a specific order. Rather than repeating th
 modules:
     enabled:
         - \SprykerTest\ApiPlatform\Helper\StorefrontApiIntegrationHelper:
+              environmentModule: '\PyzTest\Shared\Testify\Helper\Environment'
+              projectNamespaces: ['Pyz']
               publish: true
         - \PyzTest\Glue\Wishlists\Helper\WishlistsApiHelper
         - \SprykerTest\ApiPlatform\Helper\ApiPlatformHelper:
@@ -952,13 +954,18 @@ modules:
 
 `StorefrontApiIntegrationHelper` registers the integration stack: the database lane, bootstrap, locator, configuration, dependency and data cleanup, transactions, processor resolution, and the in-process Zed transport. Setting `publish: true` adds the in-process publish leg. `StorefrontApiLogicHelper` does the same for the logic tier—container resolution only, with no database and no HTTP.
 
+Two keys are yours to supply, because the core helper cannot know them:
+
+- `environmentModule` is required. It points at the project helper that defines the `APPLICATION` constants. The umbrella creates it in the one position it must occupy—after the bootstrap and before the locator freezes the configuration—which a plain entry in your `enabled` list could not guarantee.
+- `projectNamespaces` tells the class resolver about your project namespace. Without it, a module your project overrides resolves to the Spryker base class and silently loses every plugin you registered.
+
 Three rules govern the list:
 
 - Enable the umbrella helper **first**.
 - Keep `ApiPlatformHelper` **last**. Codeception runs `_afterSuite` in reverse order, and the kernel reset has to happen before the database lane deletes its work database.
 - Never re-list one of the umbrella's own child helpers after it. Codeception creates the child a second time and silently discards the configuration forwarded to the replaced instance.
 
-Per-child configuration overrides go under `modules: config:`. The exceptions are `application`, `projectNamespaces`, and `applicationPluginProvider`, which are umbrella configuration keys—setting them on a child has no effect, because the umbrella overwrites them.
+Per-child configuration overrides go under `modules: config:`. The exceptions are `application`, `projectNamespaces`, `applicationPluginProvider`, and `environmentModule`, which are umbrella configuration keys—setting them on a child has no effect, because the umbrella overwrites them.
 
 Do not enable `ContainerHelper` in an integration suite. Its `_after()` nulls the shared container delegator whenever its container was touched, and the database-fixture path touches it. That discards the compiled container between methods, so every method after the first fails with a null-container `TypeError`. The logic tier keeps `ContainerHelper`, because its container stays untouched.
 

--- a/docs/integrations/spryker-api/api-platform/testing.md
+++ b/docs/integrations/spryker-api/api-platform/testing.md
@@ -1,9 +1,11 @@
 ---
 title: Test API Platform resources
 description: Learn how to write and run tests for your API Platform resources in Spryker.
-last_updated: Jul 31, 2026
+last_updated: Aug 17, 2026
 template: howto-guide-template
 related:
+  - title: Prove API Platform contract coverage
+    link: docs/integrations/spryker-api/api-platform/contract-coverage.html
   - title: API Platform
     link: docs/integrations/spryker-api/api-platform/api-platform.html
   - title: Implement an API Platform resource
@@ -30,6 +32,25 @@ API Platform provides a comprehensive testing infrastructure built on top of:
 - **Test Helpers**: Custom helpers for test data management
 
 The testing infrastructure supports both Backend and Storefront API types with dedicated base classes and configuration.
+
+## Test tiers
+
+Tests split into two tiers by what they cover and what they cost. Put a test in the cheapest tier that can carry it.
+
+| Tier | Covers | Kernel | Cost per test |
+|---|---|---|---|
+| Logic | Provider and processor mapping, and the mapping from an error to a status. | Shared, built once per process. | About 0.4 ms, after a first boot of about 250 ms. |
+| Integration | Full-stack CRUD and the real error surface: authentication to `401` and `403`, validation to `422`, serialization and the response envelope, and `?include=` compound documents. | The real stack. | About 2–3 s, after a one-time database template build. |
+
+Both tiers resolve the system under test from the container, so both exercise the real service wiring. The difference is how far a request travels.
+
+The logic tier stubs the collaborators a test names and calls `provide()` or `process()` directly. Nothing else is stubbed, and there is no automatic doubling—a collaborator you want to control must be registered explicitly.
+
+The integration tier runs without Docker. The booted Glue kernel drives the real client and facade, and each client-to-Zed remote call is dispatched in-process to the gateway controller against a SQLite database, preserving the JSON round trip. Only OAuth token introspection is stubbed. Everything on the data path is real.
+
+Authentication and input-validation negatives belong in the integration tier even though they persist nothing, because the firewall and the framework validator answer before the data layer is reached.
+
+Do not assert on validation constraint messages or JSON structure in the logic tier. Those belong in the integration tier.
 
 ## Test architecture
 
@@ -803,20 +824,77 @@ public function testGivenUnauthorizedRequestWhenAccessingProtectedResourceThen40
 
 ## Running tests
 
-### Run all project tests (slow, not recommended)
+Both tiers run on your host without Docker and without any running service.
+
+### Generate the code the suites need
+
+The suites depend on generated code that is not in version control. Run this once per checkout, and again after any schema change:
 
 ```bash
-docker/sdk cli vendor/bin/codecept run
+vendor/bin/console transfer:generate
+vendor/bin/console transfer:databuilder:generate
+vendor/bin/console propel:schema:copy
+vendor/bin/console propel:model:build
+vendor/bin/console transfer:entity:generate
+vendor/bin/console search:setup:source-map
+GLUE_APPLICATION=GLUE_STOREFRONT vendor/bin/glue api:generate
+vendor/bin/console testify:build:sqlite-template
 ```
 
-### Run specific test suite
+The order matters. Entity transfers derive from the merged Propel schema, so the schema copy and the model build come first.
+
+`transfer:databuilder:generate` and `testify:build:sqlite-template` are registered only when development console commands are enabled:
+
+```bash
+DEVELOPMENT_CONSOLE_COMMANDS=1
+```
+
+`search:setup:source-map` writes the `Generated\Shared\Search\*IndexMap` classes. Only search-backed resources need them, but the catalog query plugins reference them while the query is being built, so a missing map is a fatal error rather than an empty result.
+
+`api:generate` is a Glue console command, so use `vendor/bin/glue` and not `vendor/bin/console`. It removes `src/Generated/Api/{ApiType}` before it parses anything, and `--dry-run` does not suppress that. An interrupted run therefore leaves no resources behind, and every test fails with `Class "Generated\Api\Storefront\…Resource" not found`. Re-run the command to recover, and pass `--keep-existing` when you only want to inspect the output.
+
+`testify:build:sqlite-template` leaves an existing template alone. Pass `--force` to drop and rebuild it after a Zed schema change, or `--path` to build it somewhere other than the configured default. A suite run rebuilds a missing template on its own, so calling it explicitly only front-loads the cost or forces a rebuild.
+
+### Run a suite
+
+```bash
+APPLICATION_ENV=devtest vendor/bin/codecept run -c tests/PyzTest/Glue/Wishlists/codeception.yml
+```
+
+### Enable the test container
+
+Both tiers resolve services from the container, which needs Symfony's test container. Turn `framework.test` on for the environment the suites run in—it is configured per application in `config/<App>/packages/framework.php`. Without it, the suites fail with `Could not find service "test.service_container"`.
+
+The container is compiled on first use and then cached, which takes roughly 45 seconds. That is a one-time cost per checkout and after any change to configuration or generated resources. Run the suites once after regenerating and the compile is behind you.
+
+### Rebuild the class-resolver cache after adding a project override
+
+`src/Generated/Shared/Kernel/Pyz/resolvableClassCache*.php` maps every resolvable class to the winning namespace, and it is read in preference to live resolution. It never expires, so a `Pyz` class added after the cache was written is silently ignored and the module resolves to the core class. There is no error—just core behavior where your project's should be. After adding an override, run:
+
+```bash
+vendor/bin/console cache:class-resolver:build
+```
+
+CI runs from a bare checkout where the file is absent and resolution is live, so this affects local runs only.
+
+### In CI
+
+The suites are found by convention. Every `tests/PyzTest/Glue/*/codeception.yml` that declares a `StorefrontApiLogic` or a `StorefrontApiIntegration` suite is picked up, one process per module configuration.
+
+Use exactly those two suite names. A new module then needs no workflow change. Use different names and the suites either run nowhere or land in the Docker lane, which they cannot survive.
+
+One process per module configuration is a requirement, not a preference. These suites boot the Glue kernel in-process and need `APPLICATION=GLUE_STOREFRONT`. The constant is process-global and first-wins, so a suite sharing a process with the Docker Glue lane inherits whatever that lane set.
+
+### Running inside Docker
+
+Test suites that predate the host lane still run through the Docker SDK:
 
 ```bash
 # Run Backend API tests only
 docker/sdk cli vendor/bin/codecept run -c path/to/codeception.yml -g BackendApi
 
 # Run Storefront API tests only
-docker/sdk cli vendor/bin/codecept run -c path/to/codeception.yml  -g StorefrontApi
+docker/sdk cli vendor/bin/codecept run -c path/to/codeception.yml -g StorefrontApi
 ```
 
 ## Codeception configuration
@@ -857,6 +935,33 @@ settings:
 - **suite_namespace**: Must match your test suite's PHP namespace
 - **actor**: The tester class name (for example, `BackendApiTester`, `StorefrontApiTester`)
 
+### Wire a suite with an umbrella helper
+
+Each tier needs a stack of helpers in a specific order. Rather than repeating that stack in every suite, enable one umbrella helper that registers it:
+
+```yaml
+modules:
+    enabled:
+        - \SprykerTest\ApiPlatform\Helper\StorefrontApiIntegrationHelper:
+              publish: true
+        - \PyzTest\Glue\Wishlists\Helper\WishlistsApiHelper
+        - \SprykerTest\ApiPlatform\Helper\ApiPlatformHelper:
+              bootOnce: true
+              reuseApplicationContainer: true
+```
+
+`StorefrontApiIntegrationHelper` registers the integration stack: the database lane, bootstrap, locator, configuration, dependency and data cleanup, transactions, processor resolution, and the in-process Zed transport. Setting `publish: true` adds the in-process publish leg. `StorefrontApiLogicHelper` does the same for the logic tier—container resolution only, with no database and no HTTP.
+
+Three rules govern the list:
+
+- Enable the umbrella helper **first**.
+- Keep `ApiPlatformHelper` **last**. Codeception runs `_afterSuite` in reverse order, and the kernel reset has to happen before the database lane deletes its work database.
+- Never re-list one of the umbrella's own child helpers after it. Codeception creates the child a second time and silently discards the configuration forwarded to the replaced instance.
+
+Per-child configuration overrides go under `modules: config:`. The exceptions are `application`, `projectNamespaces`, and `applicationPluginProvider`, which are umbrella configuration keys—setting them on a child has no effect, because the umbrella overwrites them.
+
+Do not enable `ContainerHelper` in an integration suite. Its `_after()` nulls the shared container delegator whenever its container was touched, and the database-fixture path touches it. That discards the compiled container between methods, so every method after the first fails with a null-container `TypeError`. The logic tier keeps `ContainerHelper`, because its container stays untouched.
+
 ### ApiPlatformHelper modes
 
 `ApiPlatformHelper` runs in one of two modes, selected in the suite's `codeception.yml`:
@@ -884,6 +989,43 @@ modules:
             mode: 'core'
             apiType: 'Storefront'   # or 'Backend'
 ```
+
+### Fast-path configuration keys
+
+These keys are all opt-in. Omitting one keeps the slower per-method boot with debug on.
+
+```yaml
+- \SprykerTest\ApiPlatform\Helper\ApiPlatformHelper:
+      mode: 'project'                  # or 'core'
+      apiType: 'Storefront'            # or 'Backend'
+      debug: false                     # Symfony debug off on warm resources; default true
+      bootOnce: true                   # one kernel per suite, reset between methods; default false
+      reuseApplicationContainer: true  # keep the container delegator singleton; default false
+```
+
+With `bootOnce`, the kernel is built once per process rather than once per test method. The container is still reset between methods, which is what lets each method bind its own stubs—a service already bound in the container cannot be replaced.
+
+#### Register stubs before you resolve the system under test
+
+Call `setService($id, $stub)` **before** the first `createClient()`, `getTestKernel()`, `getProcessor()`, or `getProvider()` in a test method. Stubs are bound when the kernel is taken for that method, so registering an ID after that point has no effect, and the same ID cannot be re-bound within one method once the container holds it.
+
+The container knows nothing about stubs at compile time. They are bound afterwards through Symfony's test container.
+
+### Infrastructure stand-in helpers
+
+The host lane has no Redis, no Elasticsearch, and nothing draining the queue. These helpers put a real substitute behind each one, so the code above them runs unchanged. None of them stubs the resource under test.
+
+| Helper | Stands in for | Provides |
+|---|---|---|
+| `\SprykerTest\Client\StorageDatabase\Helper\SqliteStorageHelper` | Redis, read side | Points the Storage client at the storage-database plugin, so reads hit the `spy_*_storage` tables of the lane's SQLite database. Configuration only, no methods. |
+| `\SprykerTest\Zed\Publisher\Helper\PublishHelper` | The queue | `publishPendingEvents()` drains what the test just created. `publishEntities($eventName, $ids)` publishes rows that never raised an event. The synchronization leg stays off, because it only pushes into Redis. |
+| `\SprykerTest\Shared\Testify\Helper\StorageCacheHelper` | — | `resetStorageCaches()`, plus a reset before every test. Storage clients memoize in statics that survive a container reset, so a read taken before the arrange step otherwise pins the empty result for the whole process. |
+| `\SprykerTest\Client\Search\Helper\SearchResponseStubHelper` | Elasticsearch | `stubSearchResult(array $formattedSearchResult)` takes over the search-adapter plugin list. Everything above the adapter runs for real, so the array is the post-formatting result and not a raw Elasticsearch body. |
+| `\SprykerTest\Client\Queue\Helper\QueueHelper` | — | Backs the publish leg's in-memory queue. Set `application: Zed` for a `Glue`-namespaced suite: without it, the configuration resolver guesses the application from the suite namespace, guesses `Glue`, and finds no queue configuration. The umbrella helper forces this when `publish: true`. |
+
+A storage resource whose name does not derive its table as `spy_<resource>_storage` needs an entry in `SprykerTest\Client\StorageDatabase\Sqlite\SqliteStorageDatabaseConfig`. Two exist by default: `translation` maps to `spy_glossary_storage`, and `product_search_config_extension` maps to `spy_product_search_config_storage`.
+
+Miss the `translation` entry and *every* error response becomes `PDOException: no such table`, because the error provider translates its message before rendering. The reported exception then has nothing to do with the actual failure.
 
 ### Helper classes
 
@@ -1040,6 +1182,21 @@ class CustomersBackendApiTest extends BackendApiTestCase
 }
 ```
 
+### 9. Provision fixtures through data helpers
+
+Build transfers through data builders, reached through a module's own helper. Never hand-roll a transfer in a test, and never let a test carry its own UUIDs, names, or counts.
+
+A test owns the data it asserts against. In the integration tier, that means creating the products, customers, and carts the scenario needs rather than relying on data another test or an installer left behind.
+
+Module-owned data and assertions belong in that module's helper, shipped from the core module so that projects can enable it. For example, a wishlist helper builds the transfers a stubbed client returns and asserts a resource against them:
+
+```php
+$wishlistTransfer = $this->tester->haveWishlistTransfer();   // non-persisting, logic tier
+$wishlistTransfer = $this->tester->haveWishlist();           // DB-backed, integration tier
+```
+
+The authenticated customer transfer comes from the core customer helper: `haveCustomerTransfer()` for the logic tier and `haveCustomer()` for the integration tier. The API test lanes carry no customer code of their own.
+
 ## Troubleshooting
 
 ### Generated resources not found
@@ -1134,6 +1291,7 @@ docker/sdk cli vendor/bin/codecept build
 
 ## Next steps
 
+- [Prove API Platform contract coverage](/docs/integrations/spryker-api/api-platform/contract-coverage.html) - Declare what your tests cover and gate it in CI
 - [Implement an API Platform resource](/docs/integrations/spryker-api/api-platform/enablement.html) - Creating API resources
 - [Resource schemas](/docs/integrations/spryker-api/api-platform/resource-schemas.html) - Resource schema reference
 - [Validation schemas](/docs/integrations/spryker-api/api-platform/validation-schemas.html) - Validation schema reference


### PR DESCRIPTION
The existing [testing page](https://github.com/spryker/spryker-docs/blob/master/docs/integrations/spryker-api/api-platform/testing.md) predates the harness — it covers neither the two test tiers, nor running the suites without Docker, nor the umbrella helpers that own the load-bearing module order, nor the stand-ins for infrastructure the host lane does not have.

This is the external home for information that until now lived only in code comments and in-repo READMEs, so the suite PRs can drop those comments.

**`testing.md`** gains: the two tiers and how to choose between them; the docker-free run path with the code-generation order and its caveats; suite wiring through the umbrella helpers with the three ordering rules; the fast-path config keys and the `setService()` ordering constraint; the infrastructure stand-in helpers; and fixture conventions.

**`contract-coverage.md`** is new: the `CoversApiOperation` / `CoversApiValidation` model, validation coverage per operation via validation groups, responses coming from the resource schema rather than being derived, why a response the router cannot reach must not be declared, non-servable operations, and the `api:contract:coverage` workflow.

Detail on [CC-39888](https://spryker.atlassian.net/browse/CC-39888).

## Notes for review
- The umbrella helpers are documented at their core FQCNs (`\SprykerTest\ApiPlatform\Helper\StorefrontApiIntegrationHelper` / `…\StorefrontApiLogicHelper`). They currently sit under `PyzTest\Shared\Testify\Helper` on the suite side and move to core as part of [suite#943](https://github.com/spryker/suite/pull/943), so this page should land with that.
- Two things the in-repo READMEs still say that this page deliberately does not, because they are stale: that `404` is *derived* per item operation (it is schema-declared since the response-declaration change), and that the coverage command is registered from `spryker_api_platform_contract_coverage.php` (merged into `spryker_api_platform.php`).

## Test plan
- `vale --minAlertLevel=error` — 0 errors on both pages.
- `markdownlint-cli2` — 0 errors on both pages.
- `sidebar_checker.sh` — the new page is registered; the 65 entries it reports are pre-existing DG Dev debt.
- `last_updated` bumped on `testing.md`.

[CC-39888]: https://spryker.atlassian.net/browse/CC-39888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ